### PR TITLE
Fix bridge admin-mac for consistent DHCP static leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [4.5.2] - 2026-01-17 - Fix Bridge MAC for DHCP Static Leases
+
+### Fixed
+- **Bridge admin-mac now set to match management interface** - DHCP static leases were failing because the bridge was using ether2's MAC instead of ether1's
+- Root cause: MikroTik's default config sets `auto-mac=no` with a manually assigned `admin-mac` that doesn't match the bond's `forced-mac-address`
+- The DHCP client runs on the bridge, so it was sending requests with the wrong MAC (ether2) instead of the bond's MAC (ether1)
+- Fix: After configuring management interfaces, explicitly set bridge `admin-mac` to match the management interface MAC
+
+### Technical Details
+- For LACP bonds: Bridge admin-mac is set to the bond's `forced-mac-address` (which is ether1's `orig-mac-address`)
+- For simple interfaces: Bridge admin-mac is set to the first management interface's `orig-mac-address`
+- This ensures DHCP requests use the same MAC as the static lease binding
+
+### Files Modified
+- `lib/infrastructure.js` - Added `setBridgeAdminMac()` function, modified `configureManagementInterfaces()` to track and set bridge MAC
+- `lib/configure.js` - Added same bridge admin-mac logic for standalone mode
+
 ## [4.5.1] - 2026-01-17 - Fix Docker Smoke Tests
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@
 **LACP Bonding (for redundant uplinks)**
 - LACP bonds (802.3ad) supported for devices with multiple Ethernet ports
 - Script reads first interface's MAC and sets `forced-mac-address` on bond
-- This ensures consistent MAC for DHCP static leases regardless of interface startup order
+- Script also sets bridge `admin-mac` to match (critical for DHCP static leases)
+- The DHCP client runs on the bridge, so bridge MAC must match the static lease binding
 - Note: MikroTik's `primary` parameter only affects failover, not MAC address selection
 - Requires upstream switch configured for LACP on corresponding ports
 - Example config: `managementInterfaces: [{bond: [ether1, ether2]}]`

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -65,6 +65,7 @@ async function configureMikroTik(config = {}) {
 
     // Handle management interfaces (can be simple interfaces or bonds)
     const mgmtInterfaces = config.managementInterfaces || ['ether1'];
+    let managementMac = null;  // Track MAC for bridge admin-mac
 
     // Process management interfaces
     for (const mgmtInterface of mgmtInterfaces) {
@@ -78,6 +79,19 @@ async function configureMikroTik(config = {}) {
             console.log(`✓ ${mgmtInterface} already in bridge`);
           } else {
             throw e;
+          }
+        }
+        // For simple interfaces, get the MAC of the first management interface
+        if (!managementMac) {
+          try {
+            const ethDetail = await mt.exec(`/interface ethernet print detail where default-name=${mgmtInterface}`);
+            const macMatch = ethDetail.match(/orig-mac-address=([0-9A-Fa-f:]+)/);
+            if (macMatch) {
+              managementMac = macMatch[1];
+              console.log(`✓ Using ${mgmtInterface} MAC for bridge: ${managementMac}`);
+            }
+          } catch (e) {
+            console.log(`⚠️  Could not read ${mgmtInterface} MAC: ${e.message}`);
           }
         }
       } else if (mgmtInterface.bond && Array.isArray(mgmtInterface.bond)) {
@@ -183,6 +197,22 @@ async function configureMikroTik(config = {}) {
             console.log(`⚠️  Could not enable ${member}: ${e.message}`);
           }
         }
+
+        // Use the bond's forced-mac-address for bridge admin-mac
+        if (primaryMac && !managementMac) {
+          managementMac = primaryMac;
+        }
+      }
+    }
+
+    // Set bridge admin-mac to match management interface MAC
+    // This ensures DHCP client uses the correct MAC for static leases
+    if (managementMac) {
+      try {
+        await mt.exec(`/interface bridge set bridge auto-mac=no admin-mac=${managementMac}`);
+        console.log(`✓ Set bridge admin-mac=${managementMac} (DHCP will use this MAC)`);
+      } catch (e) {
+        console.log(`⚠️  Could not set bridge admin-mac: ${e.message}`);
       }
     }
 

--- a/lib/infrastructure.js
+++ b/lib/infrastructure.js
@@ -245,11 +245,33 @@ async function configureLacpBond(mt, bondMembers, bondName = 'bond1') {
     }
   }
 
-  return bondName;
+  return { bondName, primaryMac };
+}
+
+/**
+ * Set bridge admin-mac to ensure consistent MAC for DHCP
+ * This is critical for static DHCP leases - the bridge MAC determines the DHCP client MAC
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {string} macAddress - MAC address to set on bridge
+ */
+async function setBridgeAdminMac(mt, macAddress) {
+  if (!macAddress) {
+    console.log('⚠️  No MAC address provided for bridge');
+    return;
+  }
+
+  try {
+    await mt.exec(`/interface bridge set bridge auto-mac=no admin-mac=${macAddress}`);
+    console.log(`✓ Set bridge admin-mac=${macAddress} (DHCP will use this MAC)`);
+  } catch (e) {
+    console.log(`⚠️  Could not set bridge admin-mac: ${e.message}`);
+  }
 }
 
 /**
  * Configure management interfaces (simple interfaces or LACP bonds)
+ * Also sets bridge admin-mac to match the primary management interface MAC
+ * for consistent DHCP static lease behavior
  * @param {MikroTikSSH} mt - Connected SSH session
  * @param {Object} config - Configuration with managementInterfaces array
  */
@@ -257,6 +279,7 @@ async function configureManagementInterfaces(mt, config) {
   console.log('\n=== Configuring Management Interfaces ===');
 
   const mgmtInterfaces = config.managementInterfaces || ['ether1'];
+  let managementMac = null;
 
   for (const iface of mgmtInterfaces) {
     if (typeof iface === 'string') {
@@ -267,12 +290,35 @@ async function configureManagementInterfaces(mt, config) {
           `Added ${iface} to bridge`,
           ['already have interface']
         );
+        // For simple interfaces, get the MAC of the first management interface
+        if (!managementMac) {
+          try {
+            const ethDetail = await mt.exec(`/interface ethernet print detail where default-name=${iface}`);
+            const macMatch = ethDetail.match(/orig-mac-address=([0-9A-Fa-f:]+)/);
+            if (macMatch) {
+              managementMac = macMatch[1];
+              console.log(`✓ Using ${iface} MAC for bridge: ${managementMac}`);
+            }
+          } catch (e) {
+            console.log(`⚠️  Could not read ${iface} MAC: ${e.message}`);
+          }
+        }
       } catch (e) {
         console.log(`⚠️  Could not add ${iface}: ${e.message}`);
       }
     } else if (iface.bond && Array.isArray(iface.bond)) {
-      await configureLacpBond(mt, iface.bond);
+      const { primaryMac } = await configureLacpBond(mt, iface.bond);
+      // For bonds, use the bond's forced-mac-address (which comes from first bond member)
+      if (primaryMac && !managementMac) {
+        managementMac = primaryMac;
+      }
     }
+  }
+
+  // Set bridge admin-mac to match management interface MAC
+  // This ensures DHCP client uses the correct MAC for static leases
+  if (managementMac) {
+    await setBridgeAdminMac(mt, managementMac);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- DHCP static leases were failing because the bridge was using ether2's MAC instead of ether1's
- Root cause: MikroTik's default config sets `auto-mac=no` with an `admin-mac` that doesn't match the bond's `forced-mac-address`
- Fix: After configuring management interfaces, explicitly set bridge `admin-mac` to match the management interface MAC

## Technical Details
| Interface Type | Bridge admin-mac Source |
|----------------|------------------------|
| LACP bond | Bond's `forced-mac-address` (ether1's orig-mac-address) |
| Simple interface | First management interface's `orig-mac-address` |

## Test Results
Verified fix on 3 affected devices:
- `managed-wap-south`: Now on correct static IP 10.212.255.16 ✓
- `managed-wap-north`: Now on correct static IP 10.212.255.15 ✓
- `far-bedroom-wap`: Now on correct static IP 10.212.255.17 ✓

## Files Modified
- `lib/infrastructure.js` - Added `setBridgeAdminMac()`, modified `configureManagementInterfaces()`
- `lib/configure.js` - Added same bridge admin-mac logic for standalone mode
- `CHANGELOG.md` - Added v4.5.2 entry
- `CLAUDE.md` - Updated LACP bonding documentation
- `package.json` - Bumped version to 4.5.2

## Test plan
- [x] Manually verified fix on all 3 affected devices
- [ ] Future deployments will automatically set bridge admin-mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)