### PR TITLE
Add blockedDevices for fleet-wide MAC blocking (v6.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [6.0.0] - 2026-05-01 - Fleet-Wide Device Blocking
+
+### Added — `blockedDevices` (top-level)
+
+A new top-level configuration field rejects a MAC at 802.11 association on every interface across the entire fleet. Useful for stopping reconnect storms from misbehaving clients (e.g., appliances that are firewalled at the gateway but keep retrying their cloud connection every ~20 minutes, burning airtime).
+
+Compare to existing `lockedDevices`, which pins a MAC to one specific AP (accept on target, reject elsewhere). `blockedDevices` issues reject rules everywhere with no corresponding accept rules.
+
+```yaml
+# Top level alongside ssids, devices, country
+blockedDevices:
+  - hostname: refrigerator
+    mac: FC:B9:7E:79:59:FA
+  - hostname: laundry
+    mac: FC:B9:7E:51:30:3C
+```
+
+Rules are tagged with the comment `<hostname> - blocked everywhere`. Diff-based update logic from v4.x applies: re-running with the same `blockedDevices` is a no-op.
+
+To temporarily allow a blocked device (e.g., for firmware updates):
+1. Comment the entry out, re-run apply (rules are removed).
+2. Allow at upstream firewall.
+3. After update, restore the entry, re-run apply.
+
+### Breaking — `backupAccessLists()` return shape
+
+`lib/access-list.js#backupAccessLists()` now returns `{lockedDevices, blockedDevices}` instead of a bare array of locked devices. Callers must destructure:
+
+```js
+// before (5.x)
+const lockedDevices = await backupAccessLists(mt, wifiPath);
+
+// after (6.0)
+const { lockedDevices, blockedDevices } = await backupAccessLists(mt, wifiPath);
+```
+
+In-tree callers (`lib/backup.js`, `backup-multiple-devices.js`) have been updated. External consumers using this function directly need the same change. Top-level `apply-config.js` / `apply-multiple-devices.js` flows are unaffected — `blockedDevices` is opt-in and the existing config keeps working unchanged.
+
+### Files modified
+- `lib/access-list.js` — `buildDesiredRules` accepts `blockedDevices`, `getCurrentLockingRules` filter expanded, `configureAccessLists` signature extended, `backupAccessLists` return shape changed
+- `apply-multiple-devices.js` — reads top-level `config.blockedDevices`, threads into access-list phase
+- `lib/backup.js` — destructures new return shape, stores blocked list on the config
+- `backup-multiple-devices.js` — promotes per-device `blockedDevices` to deployment level
+- `multiple-devices.example.yaml` — documents the new field
+- `package.json` — version 6.0.0
+
 ## [5.3.0] - 2026-02-09 - Fix CAPsMAN Channel Propagation
 
 ### Fixed - CAPsMAN Channel Settings Not Applied to CAP Interfaces

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The script is **idempotent** and safe to run multiple times.
 
 ### Enterprise Features
 - **LACP bonding** - Redundant management uplinks (802.3ad)
-- **WAP locking** - Lock specific clients to specific APs via access-list rules
+- **WAP locking** - Lock specific clients to specific APs via access-list rules (`lockedDevices`)
+- **Fleet-wide blocking** - Reject misbehaving clients at 802.11 association on every AP (`blockedDevices`)
 - **Remote syslog** - Centralized logging of WiFi events
 - **Automatic identity** - Device identity extracted from FQDN hostname
 

--- a/apply-multiple-devices.js
+++ b/apply-multiple-devices.js
@@ -493,7 +493,7 @@ async function main() {
       }
     }
 
-    // Phase 2.75: Configure access-lists (WAP locking)
+    // Phase 2.75: Configure access-lists (WAP locking + fleet blocking)
     // Collect lockedDevices from all device configs
     const allLockedDevices = devices.flatMap(device =>
       (device.lockedDevices || []).map(ld => ({
@@ -502,14 +502,17 @@ async function main() {
       }))
     );
 
-    if (allLockedDevices.length > 0) {
-      console.log(`\n=== Phase 2.75: Configuring Access-Lists (${allLockedDevices.length} locked device(s)) ===\n`);
+    // Top-level blockedDevices: reject across the whole fleet
+    const allBlockedDevices = config.blockedDevices || [];
+
+    if (allLockedDevices.length > 0 || allBlockedDevices.length > 0) {
+      console.log(`\n=== Phase 2.75: Configuring Access-Lists (${allLockedDevices.length} locked, ${allBlockedDevices.length} blocked) ===\n`);
       try {
-        await configureAccessLists(controllerConfig, allLockedDevices, deploymentSsids, devices);
+        await configureAccessLists(controllerConfig, allLockedDevices, deploymentSsids, devices, allBlockedDevices);
         console.log('✓ Access-list configuration complete');
       } catch (error) {
         console.error(`⚠️  Access-list configuration warning: ${error.message}`);
-        console.error('    Locked devices may not be properly configured.');
+        console.error('    Locked/blocked devices may not be properly configured.');
       }
     }
 

--- a/backup-multiple-devices.js
+++ b/backup-multiple-devices.js
@@ -385,6 +385,18 @@ async function main() {
     }
   }
 
+  // Promote blockedDevices to top level (it's fleet-wide, not per-device).
+  // The controller is the source of truth — its access-list applies to all CAPs.
+  for (const device of results.devices) {
+    if (device.blockedDevices && device.blockedDevices.length > 0) {
+      if (!results.blockedDevices) {
+        results.blockedDevices = device.blockedDevices;
+        console.log(`\nPromoted ${device.blockedDevices.length} blocked device(s) to deployment level`);
+      }
+      delete device.blockedDevices;
+    }
+  }
+
   const header = `# MikroTik Multi-Device Configuration
 # Last updated: ${new Date().toISOString()}
 # Devices: ${devices.length} (Successful: ${successCount}, Failed: ${failureCount})

--- a/lib/access-list.js
+++ b/lib/access-list.js
@@ -1,6 +1,8 @@
 /**
- * WiFi Access List configuration for WAP locking
- * Locks specific WiFi clients to specific access points using access-list rules
+ * WiFi Access List configuration for WAP locking and fleet-wide blocking
+ *
+ * - lockedDevices: pin a MAC to a specific AP (accept on target, reject elsewhere)
+ * - blockedDevices: reject a MAC on every interface across the fleet
  *
  * Uses diff-based updates to prevent mass disconnections when rules haven't changed.
  * See: https://github.com/NickBorgers/mikrotik-as-wap-configurator/issues/4
@@ -209,8 +211,8 @@ async function getCurrentLockingRules(mt, wifiPath) {
   const rules = [];
 
   try {
-    // Get all access-list rules with WAP locking comments
-    const output = await mt.exec(`${wifiPath}/access-list print detail without-paging where comment~"lock to" or comment~"locked to"`);
+    // Get all access-list rules with WAP locking or fleet-block comments
+    const output = await mt.exec(`${wifiPath}/access-list print detail without-paging where comment~"lock to" or comment~"locked to" or comment~"blocked everywhere"`);
 
     if (!output || !output.trim()) {
       return rules;
@@ -283,12 +285,13 @@ function parseRuleWithId(buffer, rules) {
 }
 
 /**
- * Build desired rules from locked devices configuration
+ * Build desired rules from locked devices and blocked devices configuration
  * @param {Array<Object>} lockedDevices - Array of { mac, hostname, lockToAp, ssid? }
  * @param {Array<Object>} allInterfaces - Array of { name, ssid, band, apIdentity }
+ * @param {Array<Object>} blockedDevices - Array of { mac, hostname }
  * @returns {Array<{mac: string, interface: string, action: string, comment: string}>}
  */
-function buildDesiredRules(lockedDevices, allInterfaces) {
+function buildDesiredRules(lockedDevices, allInterfaces, blockedDevices = []) {
   const rules = [];
 
   for (const lockedDevice of lockedDevices) {
@@ -338,6 +341,20 @@ function buildDesiredRules(lockedDevices, allInterfaces) {
         interface: iface.name,
         action: 'reject',
         comment: `${hostname} - reject (locked to ${lockToAp})`
+      });
+    }
+  }
+
+  // Fleet-wide blocks: reject the MAC on every interface, no accept rules
+  for (const blockedDevice of blockedDevices) {
+    const { mac, hostname } = blockedDevice;
+    const macUpper = mac.toUpperCase();
+    for (const iface of allInterfaces) {
+      rules.push({
+        mac: macUpper,
+        interface: iface.name,
+        action: 'reject',
+        comment: `${hostname} - blocked everywhere`
       });
     }
   }
@@ -394,7 +411,7 @@ function diffRules(currentRules, desiredRules) {
 }
 
 /**
- * Configure access-list rules for locked devices on the CAPsMAN controller
+ * Configure access-list rules for locked and blocked devices on the CAPsMAN controller.
  * Uses diff-based updates to prevent mass disconnections when rules haven't changed.
  *
  * @param {Object} controllerConfig - Controller configuration (host, username, password)
@@ -402,10 +419,13 @@ function diffRules(currentRules, desiredRules) {
  *        Each should have: { mac, hostname, lockToAp, ssid? }
  * @param {Array<Object>} deploymentSsids - Array of SSIDs in the deployment
  * @param {Array<Object>} devices - Full device configs (for determining controller identity)
+ * @param {Array<Object>} blockedDevices - Array of fleet-blocked device configs
+ *        Each should have: { mac, hostname }
  * @returns {Promise<boolean>} - Success status
  */
-async function configureAccessLists(controllerConfig, lockedDevices, deploymentSsids, devices) {
+async function configureAccessLists(controllerConfig, lockedDevices, deploymentSsids, devices, blockedDevices = []) {
   const hasLockedDevices = lockedDevices && lockedDevices.length > 0;
+  const hasBlockedDevices = blockedDevices && blockedDevices.length > 0;
 
   const mt = new MikroTikSSH(
     controllerConfig.host || '192.168.88.1',
@@ -417,7 +437,7 @@ async function configureAccessLists(controllerConfig, lockedDevices, deploymentS
     await mt.connect();
 
     console.log('\n========================================');
-    console.log('Configuring WiFi Access-Lists (WAP Locking)');
+    console.log('Configuring WiFi Access-Lists (Locking + Blocking)');
     console.log('========================================\n');
 
     // Detect WiFi package
@@ -444,10 +464,10 @@ async function configureAccessLists(controllerConfig, lockedDevices, deploymentS
       console.log(`  ⚠️  ${orphanedRules.length} rule(s) have orphaned interface references (will be removed)`);
     }
 
-    // If no locked devices to configure, remove all existing rules
-    if (!hasLockedDevices) {
+    // If no locked or blocked devices to configure, remove all existing rules
+    if (!hasLockedDevices && !hasBlockedDevices) {
       if (currentRules.length > 0) {
-        console.log('\n=== Removing All WAP Locking Rules (cleanup) ===');
+        console.log('\n=== Removing All Access-List Rules (cleanup) ===');
         for (const rule of currentRules) {
           try {
             await mt.exec(`${wifiPath}/access-list remove ${rule.id}`);
@@ -457,7 +477,7 @@ async function configureAccessLists(controllerConfig, lockedDevices, deploymentS
           }
         }
       }
-      console.log('\nℹ️  No locked devices to configure (cleanup only)');
+      console.log('\nℹ️  No locked or blocked devices to configure (cleanup only)');
       console.log('\n========================================');
       console.log('✓ Access-List Configuration Complete');
       console.log('========================================\n');
@@ -495,7 +515,7 @@ async function configureAccessLists(controllerConfig, lockedDevices, deploymentS
 
     // Build desired rules from configuration
     console.log('\n=== Computing Access-List Changes (diff-based) ===');
-    const desiredRules = buildDesiredRules(lockedDevices, allInterfaces);
+    const desiredRules = buildDesiredRules(lockedDevices || [], allInterfaces, blockedDevices || []);
 
     // Compute diff between current and desired state
     const { toAdd, toRemove, unchanged } = diffRules(currentRules, desiredRules);
@@ -589,13 +609,19 @@ async function configureAccessLists(controllerConfig, lockedDevices, deploymentS
 }
 
 /**
- * Backup access-list rules from controller and reconstruct lockedDevices config
+ * Backup access-list rules from controller and reconstruct configuration.
+ *
+ * Return shape (BREAKING in v6.0.0; previously returned just an array of locked devices):
+ *   { lockedDevices: [{ mac, hostname, lockToAp, ssid? }],
+ *     blockedDevices: [{ mac, hostname }] }
+ *
  * @param {MikroTikSSH} mt - SSH connection to controller
  * @param {string} wifiPath - WiFi path
- * @returns {Promise<Array<Object>>} - Array of { mac, hostname, lockToAp, ssid? }
+ * @returns {Promise<{lockedDevices: Array<Object>, blockedDevices: Array<Object>}>}
  */
 async function backupAccessLists(mt, wifiPath) {
   const lockedDevices = [];
+  const blockedDevices = [];
 
   try {
     console.log('\n=== Reading Access-List Configuration ===');
@@ -604,11 +630,11 @@ async function backupAccessLists(mt, wifiPath) {
 
     if (!output || !output.trim() || output.includes('no such item')) {
       console.log('  No access-list rules found');
-      return lockedDevices;
+      return { lockedDevices, blockedDevices };
     }
 
     // Parse access-list entries
-    // Format: mac-address=XX:XX:XX:XX:XX:XX interface=<name> action=accept/reject comment="hostname - lock to ap"
+    // Format: mac-address=XX:XX:XX:XX:XX:XX interface=<name> action=accept/reject comment="..."
     const rules = [];
     const lines = output.split('\n');
     let buffer = '';
@@ -627,7 +653,7 @@ async function backupAccessLists(mt, wifiPath) {
       parseAccessListRule(buffer, rules);
     }
 
-    // Group rules by MAC address to reconstruct locked device configs
+    // Group rules by MAC address
     const byMac = new Map();
     for (const rule of rules) {
       if (!byMac.has(rule.mac)) {
@@ -636,10 +662,22 @@ async function backupAccessLists(mt, wifiPath) {
       byMac.get(rule.mac).push(rule);
     }
 
-    // For each MAC, determine the lock configuration
+    // Classify each MAC as blocked-everywhere or locked-to-AP
     for (const [mac, macRules] of byMac) {
       const acceptRules = macRules.filter(r => r.action === 'accept');
       const rejectRules = macRules.filter(r => r.action === 'reject');
+
+      const blockedRule = macRules.find(r =>
+        r.action === 'reject' && /blocked everywhere/i.test(r.comment)
+      );
+      if (blockedRule && acceptRules.length === 0) {
+        // Fleet-wide block: all rules are reject, comment says "blocked everywhere"
+        const hostnameMatch = blockedRule.comment.match(/^(.+?)\s+-\s+blocked everywhere/i);
+        const hostname = hostnameMatch ? hostnameMatch[1] : mac.replace(/:/g, '').toLowerCase();
+        blockedDevices.push({ hostname, mac });
+        console.log(`  ✓ Found blocked device: ${hostname} (${mac}) — all APs`);
+        continue;
+      }
 
       if (acceptRules.length === 0) continue;
 
@@ -696,7 +734,7 @@ async function backupAccessLists(mt, wifiPath) {
     }
   }
 
-  return lockedDevices;
+  return { lockedDevices, blockedDevices };
 }
 
 /**

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -568,15 +568,19 @@ async function backupMikroTikConfig(credentials = {}) {
       console.log(`⚠️  Could not read CAPsMAN VLAN configuration: ${e.message}`);
     }
 
-    // Step 10: Read Access-List Configuration (WAP Locking)
-    // This is stored as _lockedDevices for later distribution to device configs
+    // Step 10: Read Access-List Configuration (WAP Locking + Fleet Blocking)
+    // _lockedDevices is distributed to device configs by backup-multiple-devices.js
+    // blockedDevices stays at the top level (it's fleet-wide).
     try {
       // wifi-qcom is the only supported package (v5.0.0+)
       const wifiPath = getWifiPath('wifi-qcom');
 
-      const lockedDevices = await backupAccessLists(mt, wifiPath);
+      const { lockedDevices, blockedDevices } = await backupAccessLists(mt, wifiPath);
       if (lockedDevices.length > 0) {
         config._lockedDevices = lockedDevices;
+      }
+      if (blockedDevices.length > 0) {
+        config.blockedDevices = blockedDevices;
       }
     } catch (e) {
       console.log(`⚠️  Could not read access-list configuration: ${e.message}`);

--- a/multiple-devices.example.yaml
+++ b/multiple-devices.example.yaml
@@ -27,6 +27,17 @@ syslog:
   topics:                 # Log topics to send
     - wireless            # WiFi client connect/disconnect events
 
+# Fleet-wide MAC blocks - reject these devices at 802.11 association on every AP.
+# Use for misbehaving clients (e.g., appliances firewalled at the gateway that
+# keep retrying their cloud connection every ~20min, burning airtime).
+# Compare to per-device `lockedDevices`, which pins a MAC to one specific AP.
+# Optional - omit if no devices need to be blocked fleet-wide.
+# blockedDevices:
+#   - hostname: refrigerator
+#     mac: FC:B9:7E:79:59:FA
+#   - hostname: laundry
+#     mac: FC:B9:7E:51:30:3C
+
 devices:
   # First Access Point
   - device:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,22 @@
 {
   "name": "network-config-as-code",
-  "version": "1.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "network-config-as-code",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "6.0.0",
+      "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "ssh2": "^1.17.0"
+      },
+      "bin": {
+        "mikrotik-apply": "apply-config.js",
+        "mikrotik-apply-multiple": "apply-multiple-devices.js",
+        "mikrotik-backup": "backup-config.js",
+        "mikrotik-backup-multiple": "backup-multiple-devices.js"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds a top-level `blockedDevices` field — emits 802.11 reject rules for the listed MACs across every interface on every AP.
- Targeted at clients firewalled at the gateway that still retry their cloud connection every ~20 min, burning airtime through deauth/probe/assoc/handshake/DHCP cycles. Concrete trigger: Samsung refrigerator + laundry on `managed-wap-south` 2.4GHz on `PartlyIoT`, see [host-config-as-code#19](https://github.com/NickBorgers/host-config-as-code/issues/19).
- Compare to existing `lockedDevices`, which pins a MAC to one AP via accept-here / reject-elsewhere. `blockedDevices` is reject-everywhere with no accept rules.

## Schema

```yaml
# Top level alongside ssids, devices, country
blockedDevices:
  - hostname: refrigerator
    mac: FC:B9:7E:79:59:FA
  - hostname: laundry
    mac: FC:B9:7E:51:30:3C
```

Rules are tagged with the comment `<hostname> - blocked everywhere`. Diff-based update logic from v4.x applies: re-running with the same `blockedDevices` is a no-op, and existing locked devices keep their rules untouched.

## Breaking change

`lib/access-list.js#backupAccessLists()` now returns `{lockedDevices, blockedDevices}` instead of a bare array of locked devices. In-tree callers (`lib/backup.js`, `backup-multiple-devices.js`) are updated. External consumers using this function directly need to destructure. Hence the 6.0.0 version bump.

Top-level `apply-config.js` / `apply-multiple-devices.js` flows are unaffected — `blockedDevices` is opt-in and the existing config keeps working unchanged.

## Files changed

- `lib/access-list.js` — `buildDesiredRules` accepts `blockedDevices`, `getCurrentLockingRules` filter expanded to match `blocked everywhere` comments, `configureAccessLists` signature extended, `backupAccessLists` return shape changed
- `apply-multiple-devices.js` — reads top-level `config.blockedDevices`, threads into the access-list phase
- `lib/backup.js` — destructures new return shape, stores blocked list on the config
- `backup-multiple-devices.js` — promotes per-device `blockedDevices` to deployment level on round-trip
- `multiple-devices.example.yaml` — documents the new field
- `CHANGELOG.md`, `README.md`, `package.json` — version 6.0.0 docs

## Test plan

- [x] `node --check` on all modified JS files
- [x] CI smoke tests (Docker build + module load + syntax check)
- [ ] Apply against `managed-wap-south.nickborgers.net` from host-config-as-code with the new `blockedDevices` block; confirm `/interface/wifi/access-list/print where comment~"blocked"` shows reject rows for both MACs across every interface
- [ ] Re-run apply: diff should report all rules unchanged (no churn, no disconnections)
- [ ] Backup + diff: round-trip waps.yaml through `backup-multiple-devices` and confirm `blockedDevices` is preserved at the top level

🤖 Generated with [Claude Code](https://claude.com/claude-code)