### PR TITLE
Router role with multi-WAN failover (v6.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,23 @@ route recursively through the probe route, and `check-gateway=ping` tests the
 whole path rather than just the first hop.
 
 This catches the case a next-hop check misses: a modem that has lost its own
-uplink but still answers pings on its LAN side. Measured detection time on
-hardware is 20 to 30 seconds, which matches RouterOS pinging every 10 seconds
-and requiring two consecutive failures.
+uplink but still answers pings on its LAN side.
+
+Measured on a Chateau LTE6 failing over from wired Ethernet to LTE and back:
+
+| What broke | Mechanism | Measured |
+|---|---|---|
+| Link down (cable pulled) | Probe route's next hop stops resolving; default route drops out at once | 1.2 s |
+| Link up, path beyond dead | Probe pings time out: every 10 s, two consecutive failures | 20–30 s |
+| Link restored | DHCP re-binds before the probe route resolves again | ~36 s |
 
 Failover is fast, not invisible. Each uplink has its own public address, so open
 connections through a dead uplink break and new ones use the live uplink.
+
+Known limit: the probe route pins the gateway learned at apply time. A dhcp or
+pppoe uplink that returns with a different gateway leaves that route stale, and
+the uplink will not recover until a re-apply. Applying is idempotent, so a
+scheduled re-apply covers this.
 
 Two settings exist to keep failover honest, and both are applied automatically:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,39 @@ than removed and re-added. Removing a DHCP server discards its lease table, so
 the earlier approach would have dropped every lease on a second apply. Verified
 on hardware: a seeded lease survives a re-apply.
 
+### Fixed — WiFi band token was hardcoded to 802.11ax
+
+`lib/configure.js` set `channel.band=2ghz-ax` / `5ghz-ax` unconditionally. On a
+radio that predates 802.11ax the command fails outright. New
+`detectBandToken()` in `lib/wifi-config.js` reads the radio's advertised bands
+and picks the best it supports (`2ghz-ax` > `n` > `g` > `b`; `5ghz-ax` > `ac` >
+`n` > `a`), falling back to the `-ax` token so existing ax hardware behaves
+exactly as before.
+
+Verified on an IPQ4019 radio, which advertises `2ghz-g,2ghz-n` and
+`5ghz-a,5ghz-n,5ghz-ac` and is now configured as `2ghz-n` and `5ghz-ac`.
+
+### Fixed — `country` was never read back
+
+RouterOS prints this value unquoted even though it contains a space
+(`.country=United States`). The backup matched a quoted form only, so the
+country silently never round-tripped on any role. `parseCountry()` in
+`lib/backup.js` now accepts both forms.
+
+### Fixed — untagged SSIDs were dropped from backups
+
+The SSID reader required a datapath with a VLAN, so an SSID with no `vlan` was
+skipped entirely. Untagged SSIDs are now read back, and `vlan` is omitted from
+the result rather than emitted as null. The empty `wifi.roaming` placeholder is
+no longer written either; it was not valid input.
+
+### Fixed — RouterOS detail records split on wrapped numeric lists
+
+Record splitting used `\n(?=\s*\d+\s)`, which also matches the final line of a
+wrapped numeric list such as `2g-channels=...,\n      2472`. That silently cut
+records in half and made band detection return nothing. Both splitters now
+require the index to sit at the left margin.
+
 ### Backup
 
 `backupMikroTikConfig()` detects a router by its `router:masquerade` NAT rule and
@@ -115,9 +148,10 @@ cable was unplugged.
 an untagged LAN, unlike the AP roles that tag for an upstream switch.
 
 ### Files
-- `lib/router.js` — new; the role, its helpers and its backup reader
+- `lib/router.js` — new; the role, its helpers, WiFi setup and its backup reader
+- `lib/wifi-config.js` — `detectBandToken()`; `configureWifiInterface()` accepts an undefined vlan
 - `lib/configure.js` — dispatches `role: router`
-- `lib/backup.js` — calls the router backup reader
+- `lib/backup.js` — router backup reader, `parseCountry()`, untagged-SSID support
 - `lib/index.js`, `mikrotik-no-vlan-filtering.js` — export `configureRouter`
 - `apply-config.js` — router validation and dispatch
 - `apply-multiple-devices.js` — passes `lan`/`wan` through, deploys routers alongside standalone devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,130 @@
 # Changelog
 
+## [6.1.0] - 2026-08-23 - Router Role with Multi-WAN Failover
+
+### Added — `role: router`
+
+A fourth role, alongside `standalone`, `controller` and `cap`. Those three roles
+configure access points and deliberately strip router functions. This one keeps
+them: the device is the gateway.
+
+It was built for the MikroTik Chateau LTE6 (`D53G-5HacD2HnD&EG06-A`), which
+pairs five Ethernet ports with a built-in LTE modem, and was verified on that
+hardware running RouterOS 7.18.2.
+
+```yaml
+role: router
+
+lan:
+  address: 192.168.80.1/24
+  ports: [ether2, ether3, ether4, ether5]
+  dhcpServer:
+    pool: 192.168.80.100-192.168.80.200
+    leaseTime: 12h
+  dns:
+    servers: [1.1.1.1, 8.8.8.8]
+    allowRemoteRequests: true
+
+wan:
+  - name: primary
+    interface: ether1
+    type: dhcp          # dhcp | static | pppoe | lte
+    distance: 1         # lower wins
+    probe: 8.8.8.8
+  - name: backup
+    interface: lte1
+    type: lte
+    apn: fast.t-mobile.com
+    distance: 2
+    probe: 1.1.1.1      # must differ from every other probe
+```
+
+The role configures the LAN bridge, a DHCP server, a DNS cache, masquerade NAT,
+an ordered firewall, and the uplinks with failover between them.
+
+### Failover design
+
+Each uplink gets a probe route pinning one address to that uplink, plus a
+default route whose gateway is that probe address. RouterOS resolves the default
+route recursively through the probe route, and `check-gateway=ping` tests the
+whole path rather than just the first hop.
+
+This catches the case a next-hop check misses: a modem that has lost its own
+uplink but still answers pings on its LAN side. Measured detection time on
+hardware is 20 to 30 seconds, which matches RouterOS pinging every 10 seconds
+and requiring two consecutive failures.
+
+Failover is fast, not invisible. Each uplink has its own public address, so open
+connections through a dead uplink break and new ones use the live uplink.
+
+Two settings exist to keep failover honest, and both are applied automatically:
+
+- Every uplink is created with `add-default-route=no`, so nothing competes with
+  the failover routes.
+- Every uplink is created with `use-peer-dns=no` and the router uses the
+  resolvers from `lan.dns.servers`. Keeping ISP-supplied resolvers would leave
+  the router pointing at unreachable servers after a failover — routing works,
+  every lookup times out, and it reads as a failed failover.
+
+### Interface lists
+
+The role maintains the `WAN` and `LAN` interface lists that RouterOS default
+configs already use, so one NAT rule and one firewall rule cover every uplink
+however many there are.
+
+The `WAN` list member comment is the authoritative record of each uplink's
+settings, in the form `wan:<name> type=... distance=... probe=...`. Routes only
+exist while a link is up, so reading settings back from routes alone would drop
+an unplugged uplink from the backup. The list member is always present.
+
+### Lockout safety
+
+Changing `lan.address` cuts the session applying the change. The role adds the
+new address before removing the old one, and refuses to remove the address
+carrying the current session. So the first run leaves both addresses in place,
+and a second run made over the new address clears the old one. There is never a
+moment when the device has no reachable address.
+
+### Idempotent re-apply
+
+The DHCP server, its pool and its network entry are updated in place rather
+than removed and re-added. Removing a DHCP server discards its lease table, so
+the earlier approach would have dropped every lease on a second apply. Verified
+on hardware: a seeded lease survives a re-apply.
+
+### Backup
+
+`backupMikroTikConfig()` detects a router by its `router:masquerade` NAT rule and
+reads back `lan` and `wan`, setting `role: router` so a backup re-applies
+cleanly. Verified as an exact round-trip on hardware, including an uplink whose
+cable was unplugged.
+
+### Validation
+
+`apply-config.js` rejects, before touching the device:
+
+- a missing or malformed `lan.address`
+- an empty `wan` list, or an uplink with no interface or an unknown type
+- a `static` uplink with no address or no gateway
+- two uplinks sharing a distance
+- two uplinks sharing a probe address, which would silently break the recursive
+  lookup
+- an interface listed as both a WAN and a LAN port
+
+`ssids` are optional for this role, and so is each SSID's `vlan`: a router owns
+an untagged LAN, unlike the AP roles that tag for an upstream switch.
+
+### Files
+- `lib/router.js` — new; the role, its helpers and its backup reader
+- `lib/configure.js` — dispatches `role: router`
+- `lib/backup.js` — calls the router backup reader
+- `lib/index.js`, `mikrotik-no-vlan-filtering.js` — export `configureRouter`
+- `apply-config.js` — router validation and dispatch
+- `apply-multiple-devices.js` — passes `lan`/`wan` through, deploys routers alongside standalone devices
+- `router.example.yaml` — new, fully commented
+- `README.md`, `Dockerfile`, `docker-entrypoint.sh` (`example-router`) — docs and packaging
+- `package.json` — version 6.1.0
+
 ## [6.0.0] - 2026-05-01 - Fleet-Wide Device Blocking
 
 ### Added — `blockedDevices` (top-level)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,11 +332,33 @@ const BAND_TO_INTERFACE = {
 - The role creates a per-uplink APN profile named `apn-<wan-name>` rather than editing the shared `default` profile.
 - Omit `apn` in config to set `use-network-apn=yes` and let the network supply it.
 
-**WiFi Package: This Repo Targets wifi-qcom Only**
-- `detectWifiPackage()` returns `wifi-qcom` or null. The whole WiFi codebase uses `/interface/wifi`.
-- The Chateau LTE6 ships the LEGACY `wireless` package instead: interfaces are `wlan1`/`wlan2` and commands live under `/interface wireless`, with `/interface wireless security-profiles`.
-- So router-role WiFi does NOT work on this device today. Routing, NAT, DHCP, DNS and failover all do.
-- Supporting it needs either a separate `wireless`-package code path, or installing `wifi-qcom-ac` on the device (IPQ4019 supports it) and rebooting.
+**WiFi Package: wifi-qcom Only (and the Chateau migration)**
+- `detectWifiPackage()` returns `wifi-qcom` or null. All WiFi code uses `/interface/wifi`.
+- The Chateau LTE6 SHIPS the legacy `wireless` package (wlan1/wlan2, `/interface wireless`). That is not supported.
+- The test device was migrated to `wifi-qcom-ac` (IPQ4019 supports it). Procedure, in this order:
+  1. Free space first. Only ~1.1MB was free; the npk is 2.7MB. `/system package uninstall wireless` then reboot frees ~1.9MB.
+  2. Upload `wifi-qcom-ac-<ver>-arm.npk` via SFTP (ssh2 `sftp.fastPut`; MikroTik supports the SFTP subsystem).
+  3. Reboot again to install.
+- Get the npk from `https://download.mikrotik.com/routeros/<ver>/all_packages-arm-<ver>.zip`. The download truncates often - resume with `curl -C -` in a retry loop and check the final byte count.
+- `wifi-qcom-ac` contains the substring `wifi-qcom`, so `detectWifiPackage()` accepts it unchanged.
+- Router config survived both reboots intact. Take `/export file=...` first anyway.
+
+**WiFi Band Tokens Must Be Detected, Not Assumed**
+- `channel.band=2ghz-ax` / `5ghz-ax` was hardcoded. It FAILS on any radio older than 802.11ax.
+- `detectBandToken()` in `lib/wifi-config.js` reads `/interface/wifi/radio print detail` and picks the best supported token. Preference: `2ghz-ax > n > g > b`, `5ghz-ax > ac > n > a`. Falls back to `-ax`.
+- IPQ4019 advertises `2ghz-g,2ghz-n` and `5ghz-a,5ghz-n,5ghz-ac` -> resolves to `2ghz-n` and `5ghz-ac`.
+
+**RouterOS print detail Parsing Traps (all cost real debugging time)**
+- Comments render as `;;; <comment>` lines, NOT `comment="..."`. Terse output differs from detail output.
+- `country` prints UNQUOTED despite containing a space: `.country=United States`. A quoted-only regex silently returns nothing. Use `parseCountry()` in `lib/backup.js`.
+- Multi-value fields wrap onto unlabelled continuation lines (`/ip dns print` servers, radio `bands=`).
+- Record splitting must require the index at the left margin (`\n(?=\s{0,3}\d+\s)`). A looser `\s*` also matches the last line of a wrapped numeric list such as `2g-channels=...,\n      2472`, cutting records in half.
+- Prefer scanning a whole record for a pattern over parsing exact field boundaries when the field can wrap.
+
+**Untagged SSIDs (router role)**
+- `configureWifiInterface()` omits `datapath.vlan-id` when `vlan` is undefined. No datapath object is created either.
+- `lib/backup.js` no longer requires a datapath to record an SSID, and omits `vlan` for untagged ones.
+- Validation: `vlan` is optional only when `role: router`.
 
 ### MikroTik RouterOS v7 WiFi Quirks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@
 - `apply-multiple-devices.js` - CLI tool for multi-device configuration
 - `backup-multiple-devices.js` - CLI tool for multi-device backup
 - `lib/access-list.js` - WAP locking via access-list rules
+- `lib/router.js` - Router role: multi-WAN failover, NAT, DHCP server, DNS, firewall
+- `router.example.yaml` - Example router configuration (multi-WAN failover)
 - `config.yaml` - Active device configuration (gitignored, contains credentials)
 - `config.example.yaml` - Example for documentation and Docker image
 - `multiple-devices.yaml` - Multi-device configuration file (gitignored, contains credentials)
@@ -277,6 +279,64 @@ const BAND_TO_INTERFACE = {
   /interface/wifi/access-list add mac-address="..." interface=<other-ap-interface> action=reject comment="hostname - reject (locked to ap)"
   ```
 - Debug: `/interface/wifi/access-list print detail` on controller
+
+**Router Role: Multi-WAN Failover (Added v6.1.0)**
+- Fourth role alongside `standalone`, `controller`, `cap`. The device is the gateway, not an AP.
+- The AP roles strip router functions on purpose (`lib/configure.js` removes DHCP servers, NAT, static bridge IPs, DNS). The router role keeps them. Never mix the two on one device.
+- Implemented in `lib/router.js`; dispatched from `lib/configure.js`.
+- Verified on the Chateau LTE6 (`D53G-5HacD2HnD&EG06-A`, RouterOS 7.18.2, 5 ether ports + lte1).
+- Config shape:
+  ```yaml
+  role: router
+  lan:
+    address: 192.168.80.1/24
+    ports: [ether2, ether3, ether4, ether5]
+    dhcpServer: {pool: 192.168.80.100-192.168.80.200, leaseTime: 12h}
+    dns: {servers: [1.1.1.1, 8.8.8.8], allowRemoteRequests: true}
+  wan:
+    - {name: primary, interface: ether1, type: dhcp, distance: 1, probe: 8.8.8.8}
+    - {name: backup, interface: lte1, type: lte, apn: fast.t-mobile.com, distance: 2, probe: 1.1.1.1}
+  ```
+- WAN types: `dhcp`, `static`, `pppoe`, `lte`.
+
+**Recursive-Route Failover (Why, Not Just What)**
+- Each uplink gets a probe route (`dst-address=<probe>/32 gateway=<gw> scope=10`) plus a default route whose gateway IS the probe address (`gateway=<probe> target-scope=11 distance=<n> check-gateway=ping`).
+- RouterOS resolves the default route recursively through the probe route.
+- This detects a dead ISP behind a live modem. A modem that lost its uplink still answers ARP/ping on its LAN side, so plain `check-gateway=ping` on the next hop never notices.
+- Measured detection on hardware: 20-30s (RouterOS pings every 10s, needs 2 consecutive failures). Do not claim 5-15s.
+- Failover is fast, NOT seamless. Each uplink has its own public IP, so open connections break. Only an overlay tunnel would keep them.
+- Every uplink is created with `add-default-route=no` so nothing competes with these routes.
+- Every uplink gets `use-peer-dns=no` and the router uses `lan.dns.servers`. Keeping ISP resolvers means that after failover, routing works but every lookup times out - which reads as a failed failover and is very hard to diagnose.
+- Each uplink needs its OWN probe address. Two uplinks sharing one probe fight over the same probe route. Validation rejects this.
+
+**Router Role: Interface Lists and Comment Conventions**
+- Maintains the `WAN` and `LAN` interface lists that RouterOS defconf already uses. One NAT rule (`out-interface-list=WAN`) and one firewall rule cover every uplink.
+- The `WAN` list member comment is the AUTHORITATIVE record: `wan:<name> type=... distance=... probe=... [apn=...]`.
+- Why: routes only exist while a link is up. Reading settings back from routes alone drops an unplugged uplink from the backup. The list member is always present.
+- Other comments: routes `wan:<name> probe` / `wan:<name> default`, NAT `router:masquerade`, filter `router:<purpose>`, DHCP/pool/address `router:lan`.
+- Backup detects the role via the `router:masquerade` NAT rule, not via routes, for the same reason.
+- RouterOS `print detail` renders comments as `;;; <comment>` lines, NOT as `comment="..."`. Parse with `recordComment()` in `lib/router.js`. Getting this wrong silently returns nothing.
+- `/ip dns print` wraps a multi-server list onto unlabelled continuation lines. Collect lines until the next `label:`.
+
+**Router Role: Lockout Safety**
+- Changing `lan.address` cuts the SSH session doing the work. This repo already has a lockout history (VLAN filtering, 3 times).
+- `addLanAddress()` runs before the DHCP server (which needs the address to exist). `removeStaleLanAddresses()` runs last and REFUSES to remove the address whose subnet contains `config.host`.
+- Result: run 1 over the old address leaves both addresses live. Run 2 over the new address removes the old one. Never a moment with no reachable address.
+- Firewall order is deliberate: accept established, drop invalid, accept ICMP, accept `in-interface-list=LAN`, and only THEN drop `in-interface-list=!LAN`. The drop rule is skipped entirely if the LAN list cannot be verified to contain `bridge`.
+- Fasttrack is OFF by default (`lan.fasttrack: true` to enable). Fasttracked flows skip connection tracking, which slows how fast stale sessions clear after a failover.
+
+**LTE Notes (Chateau LTE6 / EG06-A)**
+- `/interface lte monitor lte1 once` showing `status: connected` only means the modem attached to the tower. It does NOT mean the data session has an IP.
+- If there is no address on lte1 and no default route, the APN is wrong. Check `/ip address print where interface=lte1`.
+- Verified working APN on a Google Fi SIM: `fast.t-mobile.com`. `h2g2` did NOT work, despite being the commonly cited Google Fi APN.
+- The role creates a per-uplink APN profile named `apn-<wan-name>` rather than editing the shared `default` profile.
+- Omit `apn` in config to set `use-network-apn=yes` and let the network supply it.
+
+**WiFi Package: This Repo Targets wifi-qcom Only**
+- `detectWifiPackage()` returns `wifi-qcom` or null. The whole WiFi codebase uses `/interface/wifi`.
+- The Chateau LTE6 ships the LEGACY `wireless` package instead: interfaces are `wlan1`/`wlan2` and commands live under `/interface wireless`, with `/interface wireless security-profiles`.
+- So router-role WiFi does NOT work on this device today. Routing, NAT, DHCP, DNS and failover all do.
+- Supporting it needs either a separate `wireless`-package code path, or installing `wifi-qcom-ac` on the device (IPQ4019 supports it) and rebooting.
 
 ### MikroTik RouterOS v7 WiFi Quirks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,12 @@ const BAND_TO_INTERFACE = {
 - Each uplink gets a probe route (`dst-address=<probe>/32 gateway=<gw> scope=10`) plus a default route whose gateway IS the probe address (`gateway=<probe> target-scope=11 distance=<n> check-gateway=ping`).
 - RouterOS resolves the default route recursively through the probe route.
 - This detects a dead ISP behind a live modem. A modem that lost its uplink still answers ARP/ping on its LAN side, so plain `check-gateway=ping` on the next hop never notices.
-- Measured detection on hardware: 20-30s (RouterOS pings every 10s, needs 2 consecutive failures). Do not claim 5-15s.
+- TWO detection paths, very different speeds. Measured on the Chateau LTE6 (wired <-> LTE):
+  - Link DOWN (cable pulled / port disabled): the probe route's next hop stops resolving, so the default route deactivates immediately. **1.2s**. No ping timeout involved.
+  - Link UP but path beyond it dead (ISP down behind live modem): must wait for probe pings to fail. **20-30s** (every 10s, 2 consecutive failures). This is the case the recursive design exists for.
+  - Failback after the link returns: **~36s**, dominated by DHCP re-binding before the probe route can resolve.
+- Do not quote a single number. Say which failure mode.
+- STALE GATEWAY LIMIT: the probe route pins the gateway learned at apply time. If a dhcp/pppoe uplink returns with a DIFFERENT gateway, the pinned route is stale and that uplink will not recover until a re-apply. Apply is idempotent, so a scheduled re-apply covers it.
 - Failover is fast, NOT seamless. Each uplink has its own public IP, so open connections break. Only an overlay tunnel would keep them.
 - Every uplink is created with `add-default-route=no` so nothing competes with these routes.
 - Every uplink gets `use-peer-dns=no` and the router uses `lan.dns.servers`. Keeping ISP resolvers means that after failover, routing works but every lookup times out - which reads as a failed failover and is very hard to diagnose.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY backup-multiple-devices.js ./
 COPY mikrotik-no-vlan-filtering.js ./
 COPY lib ./lib
 COPY config.example.yaml ./
+COPY router.example.yaml ./
 COPY multiple-devices.example.yaml ./
 COPY diag ./diag
 

--- a/README.md
+++ b/README.md
@@ -183,12 +183,106 @@ The script is **idempotent** and safe to run multiple times.
 - **Local WiFi fallback** - CAPs continue working if controller goes offline
 - See `multiple-devices.example.yaml` for CAPsMAN configuration examples
 
+### Router Mode with Multi-WAN Failover
+- **Router role** - The device is the gateway, not an access point (`role: router`)
+- **Multiple uplinks** - Ethernet, LTE, PPPoE and static WANs in one config
+- **Automatic failover** - Traffic moves to the next uplink when one dies
+- **Path-aware health checks** - Probes a real internet address, not just the next hop
+- **Full gateway stack** - NAT, DHCP server, DNS cache and a firewall
+- See `router.example.yaml` for a complete configuration
+
 ### Enterprise Features
 - **LACP bonding** - Redundant management uplinks (802.3ad)
 - **WAP locking** - Lock specific clients to specific APs via access-list rules (`lockedDevices`)
 - **Fleet-wide blocking** - Reject misbehaving clients at 802.11 association on every AP (`blockedDevices`)
 - **Remote syslog** - Centralized logging of WiFi events
 - **Automatic identity** - Device identity extracted from FQDN hostname
+
+## Router Mode
+
+Most of this tool configures access points that sit behind someone else's
+gateway. Those roles deliberately strip router functions. Router mode does the
+opposite: the device *is* the gateway.
+
+Set `role: router` and describe two things, the LAN it owns and the uplinks it
+can use.
+
+```yaml
+role: router
+
+lan:
+  address: 192.168.80.1/24
+  ports: [ether2, ether3, ether4, ether5]
+  dhcpServer:
+    pool: 192.168.80.100-192.168.80.200
+    leaseTime: 12h
+  dns:
+    servers: [1.1.1.1, 8.8.8.8]
+
+wan:
+  - name: primary
+    interface: ether1
+    type: dhcp        # dhcp | static | pppoe | lte
+    distance: 1       # lower wins
+    probe: 8.8.8.8
+  - name: backup
+    interface: lte1
+    type: lte
+    apn: fast.t-mobile.com
+    distance: 2
+    probe: 1.1.1.1    # must differ from every other probe
+```
+
+Apply it the same way as any other config:
+
+```bash
+./apply-config.js router.yaml
+```
+
+### How failover works
+
+Each uplink gets two routes. A **probe route** pins one address to that uplink.
+A **default route** points at the probe address rather than a real next hop, so
+the router has to resolve it through the probe route.
+
+The router then pings the probe address every 10 seconds. Two failures in a row
+mark that uplink down, and the next one takes over. Detection takes roughly 20
+to 30 seconds.
+
+Probing a real internet address is the point. A cable modem that has lost its
+own uplink still answers pings on its LAN side, so checking only the next hop
+would never notice. Checking `8.8.8.8` does.
+
+Give every uplink its own probe address. Two uplinks sharing one address would
+fight over the same probe route. The tool rejects that at validation time.
+
+### What failover does and does not do
+
+Failover here is fast, not invisible. Each uplink has its own public address, so
+open connections through a dead uplink break. New connections use the live one.
+Expect a gap of under a minute, then normal service.
+
+Surviving the switch without dropping connections needs an overlay tunnel that
+keeps one address across both uplinks. This tool does not set that up.
+
+### Two details that matter
+
+**Resolvers are static.** The uplinks are configured with `use-peer-dns=no`, and
+the router uses the servers in `lan.dns.servers`. If it kept the resolvers its
+ISP handed out, then after a failover it would still point at servers it can no
+longer reach. Routing would work, every lookup would time out, and it would look
+like the failover had failed.
+
+**The tool owns the default routes.** Every uplink is created with
+`add-default-route=no`, so nothing competes with the failover routes.
+
+### Changing the LAN address safely
+
+Moving `lan.address` cuts the session applying the change. The tool adds before
+it removes, so this takes two runs and never leaves the device unreachable:
+
+1. Run over the old address. The new address is added; the old one stays.
+2. Reconnect at the new address and run again. The old address is removed.
 
 ## Multi-Device Management
 
@@ -472,6 +566,7 @@ network-config-as-code/
 ├── lib/                         # Core library modules
 │   ├── index.js                 # Public API exports
 │   ├── configure.js             # Main configureMikroTik entry point
+│   ├── router.js                # Router role: multi-WAN failover, NAT, DHCP
 │   ├── capsman.js               # CAPsMAN controller/CAP functions
 │   ├── backup.js                # Device backup functionality
 │   ├── access-list.js           # WAP locking via access-list rules
@@ -487,6 +582,7 @@ network-config-as-code/
 │   └── wait-for-device.js       # Wait for device after reboot
 ├── config.yaml                  # Single device config (gitignored)
 ├── config.example.yaml          # Example single device config
+├── router.example.yaml          # Example router config (multi-WAN failover)
 ├── multiple-devices.yaml        # Multi-device config (gitignored)
 ├── multiple-devices.example.yaml # Example multi-device config
 ├── configure-device.sh          # Automated setup script

--- a/README.md
+++ b/README.md
@@ -245,13 +245,24 @@ Each uplink gets two routes. A **probe route** pins one address to that uplink.
 A **default route** points at the probe address rather than a real next hop, so
 the router has to resolve it through the probe route.
 
-The router then pings the probe address every 10 seconds. Two failures in a row
-mark that uplink down, and the next one takes over. Detection takes roughly 20
-to 30 seconds.
-
 Probing a real internet address is the point. A cable modem that has lost its
 own uplink still answers pings on its LAN side, so checking only the next hop
 would never notice. Checking `8.8.8.8` does.
+
+Two different failures are detected two different ways, and they are not
+equally fast:
+
+| What broke | How it is caught | Measured |
+|---|---|---|
+| The link went down (cable pulled, port died) | The probe route's next hop stops resolving, so the default route drops out at once | **1.2 s** |
+| The link is up but the path beyond it is dead (ISP down behind a live modem) | The probe pings have to time out: every 10 s, two failures in a row | **20–30 s** |
+| The link came back | Waiting on DHCP to re-bind before the probe route can resolve again | **~36 s** |
+
+Both numbers come from a MikroTik Chateau LTE6 failing over from wired Ethernet
+to LTE and back.
+
+The second row is the case this design exists for. A next-hop check would sit
+there indefinitely, satisfied that the modem still answers.
 
 Give every uplink its own probe address. Two uplinks sharing one address would
 fight over the same probe route. The tool rejects that at validation time.
@@ -275,6 +286,17 @@ like the failover had failed.
 
 **The tool owns the default routes.** Every uplink is created with
 `add-default-route=no`, so nothing competes with the failover routes.
+
+### A limit worth knowing
+
+The probe route pins the gateway that was learned when the config was applied.
+If a DHCP or PPPoE uplink comes back with a *different* gateway than it had
+before, that pinned route is stale and the uplink will not recover on its own.
+
+Re-applying fixes it, and applying is idempotent, so a scheduled re-apply
+covers this. It has not bitten in testing, where the returning link kept its
+lease, but it is real. A netwatch script that rewrote the gateway would close
+the gap at the cost of keeping imperative state outside the config file.
 
 ### Changing the LAN address safely
 

--- a/apply-config.js
+++ b/apply-config.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const { configureMikroTik } = require('./mikrotik-no-vlan-filtering.js');
 const { configureCap, configureController } = require('./lib/capsman');
+const { configureRouter } = require('./lib/router');
 
 function loadConfig(configFile) {
   try {
@@ -16,8 +17,79 @@ function loadConfig(configFile) {
   }
 }
 
+const VALID_WAN_TYPES = ['dhcp', 'static', 'pppoe', 'lte'];
+
+/**
+ * Validate the lan and wan blocks of a router-role configuration.
+ * Returns an array of error strings.
+ */
+function validateRouterConfig(config) {
+  const errors = [];
+  const lan = config.lan || {};
+  const wans = config.wan || [];
+
+  if (!lan.address) {
+    errors.push('Router: missing lan.address (e.g. 192.168.80.1/24)');
+  } else if (!/^\d+\.\d+\.\d+\.\d+\/\d{1,2}$/.test(lan.address)) {
+    errors.push(`Router: lan.address '${lan.address}' is not valid CIDR (e.g. 192.168.80.1/24)`);
+  }
+
+  if (!Array.isArray(wans) || wans.length === 0) {
+    errors.push('Router: wan must be a non-empty list of uplinks');
+    return errors;
+  }
+
+  const probes = new Map();
+  const distances = new Map();
+  const lanPorts = new Set(lan.ports || []);
+
+  wans.forEach((wan, index) => {
+    const label = wan.name || `wan[${index}]`;
+
+    if (!wan.interface) {
+      errors.push(`Router: ${label} is missing interface`);
+    } else if (lanPorts.has(wan.interface)) {
+      errors.push(`Router: ${wan.interface} is listed both as a WAN and in lan.ports - pick one`);
+    }
+
+    const type = wan.type || 'dhcp';
+    if (!VALID_WAN_TYPES.includes(type)) {
+      errors.push(`Router: ${label} has invalid type '${type}' (use ${VALID_WAN_TYPES.join(', ')})`);
+    }
+    if (type === 'static' && !wan.address) {
+      errors.push(`Router: ${label} is type static but has no address`);
+    }
+    if (type === 'static' && !wan.gateway) {
+      errors.push(`Router: ${label} is type static but has no gateway`);
+    }
+
+    if (wan.distance !== undefined) {
+      if (!Number.isInteger(wan.distance) || wan.distance < 1 || wan.distance > 255) {
+        errors.push(`Router: ${label} distance must be a whole number from 1 to 255`);
+      } else if (distances.has(wan.distance)) {
+        errors.push(`Router: ${label} and ${distances.get(wan.distance)} share distance ${wan.distance} - each uplink needs its own`);
+      } else {
+        distances.set(wan.distance, label);
+      }
+    }
+
+    // Two uplinks probing the same address would fight over one probe route,
+    // and the recursive lookup would silently follow whichever won.
+    if (wan.probe) {
+      if (probes.has(wan.probe)) {
+        errors.push(`Router: ${label} and ${probes.get(wan.probe)} both probe ${wan.probe} - each uplink needs its own target`);
+      } else {
+        probes.set(wan.probe, label);
+      }
+    }
+  });
+
+  return errors;
+}
+
 function validateConfig(config) {
   const errors = [];
+  const role = config.role || 'standalone';
 
   if (!config.device) {
     errors.push('Missing device configuration');
@@ -27,8 +99,14 @@ function validateConfig(config) {
     if (!config.device.password) errors.push('Missing device.password');
   }
 
-  // CAP devices don't need SSIDs - they receive them from the controller
-  if (config.role !== 'cap' && (!config.ssids || config.ssids.length === 0)) {
+  if (role === 'router') {
+    errors.push(...validateRouterConfig(config));
+  }
+
+  // CAP devices receive SSIDs from the controller.
+  // Routers may legitimately run with no WiFi at all.
+  const ssidsOptional = role === 'cap' || role === 'router';
+  if (!ssidsOptional && (!config.ssids || config.ssids.length === 0)) {
     errors.push('No SSIDs defined');
   }
 
@@ -39,7 +117,10 @@ function validateConfig(config) {
       if (ssid.passphrase === 'UNKNOWN') {
         errors.push(`SSID ${index} (${ssid.ssid}): passphrase is UNKNOWN - please set a real passphrase. UNKNOWN is used in backups when passphrases cannot be retrieved from devices.`);
       }
-      if (ssid.vlan === undefined) errors.push(`SSID ${index}: missing vlan`);
+      // A router owns its LAN, which is untagged, so vlan is optional there.
+      if (ssid.vlan === undefined && role !== 'router') {
+        errors.push(`SSID ${index}: missing vlan`);
+      }
       if (!ssid.bands || ssid.bands.length === 0) {
         errors.push(`SSID ${index}: missing bands (must specify 2.4GHz, 5GHz, or both)`);
       }
@@ -95,6 +176,9 @@ async function main() {
     managementInterfaces: config.managementInterfaces || ['ether1'],
     disabledInterfaces: config.disabledInterfaces || [],
     igmpSnooping: config.igmpSnooping,  // IGMP snooping on bridge
+    role: config.role,
+    lan: config.lan,    // Router role: LAN address, ports, DHCP server, DNS
+    wan: config.wan,    // Router role: uplinks with failover ordering
     wifi: config.wifi,  // WiFi optimization settings (channel, power, roaming)
     securityProfile: config.security?.profile || 'wpa2-vlan100',
     passphrase: config.security?.passphrase || 'password',
@@ -115,7 +199,17 @@ async function main() {
   });
 
   console.log(`Management interfaces: ${mgmtDisplay.join(', ')}`);
-  if (config.role === 'cap') {
+  if (config.role === 'router') {
+    console.log(`Role: Router (multi-WAN gateway)`);
+    console.log(`LAN: ${config.lan?.address || 'unset'}`);
+    (config.wan || []).forEach(wan => {
+      const dist = wan.distance !== undefined ? wan.distance : '?';
+      console.log(`  - ${wan.name || wan.interface}: ${wan.interface} (${wan.type || 'dhcp'}), distance ${dist}`);
+    });
+    if (config.ssids?.length) {
+      console.log(`SSIDs to configure: ${config.ssids.length}`);
+    }
+  } else if (config.role === 'cap') {
     console.log(`Role: CAP (SSIDs received from controller)`);
   } else if (config.ssids) {
     console.log(`SSIDs to configure: ${config.ssids.length}`);
@@ -131,7 +225,14 @@ async function main() {
   console.log('');
 
   try {
-    if (config.role === 'cap' || config.role === 'controller') {
+    if (config.role === 'router') {
+      await configureRouter({
+        ...config,
+        host: targetIp || config.device.host,
+        username: config.device.username,
+        password: config.device.password
+      });
+    } else if (config.role === 'cap' || config.role === 'controller') {
       // CAP/controller functions expect flat config with host/username/password at root
       const flatConfig = {
         ...config,

--- a/apply-multiple-devices.js
+++ b/apply-multiple-devices.js
@@ -99,6 +99,9 @@ function validateDeviceConfig(config, index, deploymentSsids) {
         }
       });
     }
+  } else if (role === 'router') {
+    // Routers are validated by apply-config's router rules; SSIDs are optional
+    // and no CAPsMAN ordering applies. Nothing extra to check here.
   } else {
     // Controller and standalone devices need SSIDs
     const ssids = config.ssids || [];
@@ -355,6 +358,8 @@ async function main() {
       managementInterfaces: deviceConfig.managementInterfaces || ['ether1'],
       disabledInterfaces: deviceConfig.disabledInterfaces || [],
       igmpSnooping: deviceConfig.igmpSnooping,
+      lan: deviceConfig.lan,    // Router role: LAN address, ports, DHCP server, DNS
+      wan: deviceConfig.wan,    // Router role: uplinks with failover ordering
       wifi,
       syslog: deploymentSyslog,
       ssids,
@@ -375,7 +380,7 @@ async function main() {
   if (capsmanMode) {
     const controller = devices.find(d => d.role === 'controller');
     const caps = devices.filter(d => d.role === 'cap');
-    const standalones = devices.filter(d => !d.role || d.role === 'standalone');
+    const standalones = devices.filter(d => !d.role || d.role === 'standalone' || d.role === 'router');
 
     // Phase 1: Configure controller
     console.log('=== Phase 1: Configuring CAPsMAN Controller ===\n');

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,7 @@ COMMANDS:
   apply-multiple     Apply multi-device configuration
   example            Output example single-device config.yaml
   example-multiple   Output example multiple-devices.yaml
+  example-router     Output example router.yaml (multi-WAN failover)
   help               Show this help message
 
 SINGLE-DEVICE EXAMPLES:
@@ -73,6 +74,11 @@ show_example() {
     cat /app/config.example.yaml
 }
 
+# Function to show example router config
+show_example_router() {
+    cat /app/router.example.yaml
+}
+
 # Function to show example multi-device config
 show_example_multiple() {
     cat /app/multiple-devices.example.yaml
@@ -88,6 +94,10 @@ case "${1:-apply}" in
         show_example
         exit 0
         ;;
+    example-router)
+        show_example_router
+        ;;
+
     example-multiple)
         show_example_multiple
         exit 0

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -10,6 +10,26 @@ const { backupRouterConfig } = require('./router');
 const { getWifiPath } = require('./utils');
 
 /**
+ * Pull a country name out of RouterOS "print detail" output.
+ *
+ * RouterOS prints this value unquoted even though it contains a space, e.g.
+ * `.country=United States`, so a quoted-only match silently finds nothing.
+ * Both forms are accepted here.
+ *
+ * @param {string} output - Raw print detail output
+ * @returns {string|null}
+ */
+function parseCountry(output) {
+  if (!output) return null;
+  const quoted = output.match(/\.?country="([^"]+)"/);
+  if (quoted) return quoted[1];
+
+  // Unquoted: run to the next `key=` token or the end of the line.
+  const bare = output.match(/\.?country=((?:(?!\s+[\w.-]+=)[^\r\n])+)/);
+  return bare ? bare[1].trim() : null;
+}
+
+/**
  * Backup current MikroTik configuration and generate config.yaml structure
  * @param {Object} credentials - Device credentials {host, username, password}
  * @returns {Promise<Object>} Configuration object matching config.yaml schema
@@ -221,7 +241,7 @@ async function backupMikroTikConfig(credentials = {}) {
       const wifi1Output = await mt.exec('/interface wifi print detail without-paging where default-name=wifi1');
       const channelFreqMatch24 = wifi1Output.match(/channel\.frequency=(\d+)/);
       const txPowerMatch24 = wifi1Output.match(/(?:configuration\.)?tx-power=(\d+)/);
-      const countryMatch24 = wifi1Output.match(/(?:configuration\.)?country="([^"]+)"/);
+      const country24Value = parseCountry(wifi1Output);
       const widthMatch24 = wifi1Output.match(/(?:channel\.)?width=([^\s]+)/);
 
       if (channelFreqMatch24) {
@@ -241,9 +261,9 @@ async function backupMikroTikConfig(credentials = {}) {
         console.log(`✓ 2.4GHz TX Power: ${txPowerMatch24[1]} dBm`);
       }
 
-      if (countryMatch24) {
-        config.wifi['2.4GHz'].country = countryMatch24[1];
-        console.log(`✓ 2.4GHz Country: ${countryMatch24[1]}`);
+      if (country24Value) {
+        config.wifi['2.4GHz'].country = country24Value;
+        console.log(`✓ 2.4GHz Country: ${country24Value}`);
       }
 
       if (widthMatch24) {
@@ -255,7 +275,7 @@ async function backupMikroTikConfig(credentials = {}) {
       const wifi2Output = await mt.exec('/interface wifi print detail without-paging where default-name=wifi2');
       const channelFreqMatch5 = wifi2Output.match(/channel\.frequency=(\d+)/);
       const txPowerMatch5 = wifi2Output.match(/(?:configuration\.)?tx-power=(\d+)/);
-      const countryMatch5 = wifi2Output.match(/(?:configuration\.)?country="([^"]+)"/);
+      const country5Value = parseCountry(wifi2Output);
       const widthMatch5 = wifi2Output.match(/(?:channel\.)?width=([^\s]+)/);
 
       if (channelFreqMatch5) {
@@ -275,9 +295,9 @@ async function backupMikroTikConfig(credentials = {}) {
         console.log(`✓ 5GHz TX Power: ${txPowerMatch5[1]} dBm`);
       }
 
-      if (countryMatch5) {
-        config.wifi['5GHz'].country = countryMatch5[1];
-        console.log(`✓ 5GHz Country: ${countryMatch5[1]}`);
+      if (country5Value) {
+        config.wifi['5GHz'].country = country5Value;
+        console.log(`✓ 5GHz Country: ${country5Value}`);
       }
 
       if (widthMatch5) {
@@ -311,6 +331,12 @@ async function backupMikroTikConfig(credentials = {}) {
       }
       if (Object.keys(config.wifi['5GHz']).length === 0) {
         delete config.wifi['5GHz'];
+      }
+
+      // The roaming placeholder is never populated here; leaving it in emits an
+      // empty map that is not valid input.
+      if (config.wifi.roaming && Object.keys(config.wifi.roaming).length === 0) {
+        delete config.wifi.roaming;
       }
 
       if (Object.keys(config.wifi).length === 0) {
@@ -371,7 +397,10 @@ async function backupMikroTikConfig(credentials = {}) {
         const passphrase = passphraseMatch ? passphraseMatch[1] : null;
         const isMaster = !masterMatch;
 
-        if (ssid && datapathName) {
+        // A datapath is only present when the SSID is tagged. Router-role
+        // SSIDs ride the bridge untagged and have none, so requiring one here
+        // would silently drop them from the backup.
+        if (ssid) {
           iface.name = name;
           iface.ssid = ssid;
           iface.datapathName = datapathName;
@@ -417,13 +446,13 @@ async function backupMikroTikConfig(credentials = {}) {
       const ssidMap = new Map();
 
       for (const iface of interfaces) {
-        if (!iface.ssid || !iface.band || !iface.datapathName) continue;
+        if (!iface.ssid || !iface.band) continue;
 
-        const vlan = datapaths[iface.datapathName];
-        if (vlan === undefined) continue;
+        // undefined means untagged, which is valid for the router role.
+        const vlan = iface.datapathName ? datapaths[iface.datapathName] : undefined;
 
         // Group by SSID+VLAN+passphrase
-        const key = `${iface.ssid}|${vlan}|${iface.passphrase || ''}`;
+        const key = `${iface.ssid}|${vlan === undefined ? 'untagged' : vlan}|${iface.passphrase || ''}`;
 
         if (!ssidMap.has(key)) {
           ssidMap.set(key, {
@@ -450,9 +479,13 @@ async function backupMikroTikConfig(credentials = {}) {
         const result = {
           ssid: ssidConfig.ssid,
           passphrase: ssidConfig.passphrase,
-          vlan: ssidConfig.vlan,
           bands: ssidConfig.bands
         };
+
+        // Omit vlan entirely for untagged SSIDs, matching how they are written.
+        if (ssidConfig.vlan !== undefined) {
+          result.vlan = ssidConfig.vlan;
+        }
 
         // Add roaming config if FT is enabled for this SSID
         if (ssidConfig.hasFastTransition) {
@@ -465,7 +498,7 @@ async function backupMikroTikConfig(credentials = {}) {
       for (const ssid of config.ssids) {
         console.log(`✓ SSID: ${ssid.ssid}`);
         console.log(`  Bands: ${ssid.bands.join(', ')}`);
-        console.log(`  VLAN: ${ssid.vlan}`);
+        console.log(`  VLAN: ${ssid.vlan === undefined ? 'untagged' : ssid.vlan}`);
         if (ssid.roaming?.fastTransition) {
           console.log(`  802.11r: enabled`);
         }
@@ -617,4 +650,4 @@ async function backupMikroTikConfig(credentials = {}) {
   }
 }
 
-module.exports = { backupMikroTikConfig };
+module.exports = { backupMikroTikConfig, parseCountry };

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -6,6 +6,7 @@
 const { MikroTikSSH } = require('./ssh-client');
 const { FREQ_CHANNEL_24GHZ, FREQ_CHANNEL_5GHZ } = require('./constants');
 const { backupAccessLists } = require('./access-list');
+const { backupRouterConfig } = require('./router');
 const { getWifiPath } = require('./utils');
 
 /**
@@ -584,6 +585,23 @@ async function backupMikroTikConfig(credentials = {}) {
       }
     } catch (e) {
       console.log(`⚠️  Could not read access-list configuration: ${e.message}`);
+    }
+
+    // Step 11: Read Router Configuration (role: router)
+    // Detected by the wan: route comments this tool writes during apply.
+    // A router's LAN ports are not "management interfaces", so that WAP-only
+    // field is dropped when this matches.
+    try {
+      const router = await backupRouterConfig(mt);
+      if (router) {
+        config.role = 'router';
+        config.lan = router.lan;
+        config.wan = router.wan;
+        delete config.managementInterfaces;
+        delete config.disabledInterfaces;
+      }
+    } catch (e) {
+      console.log(`⚠️  Could not read router configuration: ${e.message}`);
     }
 
     console.log('\n========================================');

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -15,6 +15,7 @@ const {
   configureSyslog
 } = require('./infrastructure');
 const { configureController, configureCap } = require('./capsman');
+const { configureRouter } = require('./router');
 
 /**
  * Main configuration function - dispatches based on role
@@ -29,6 +30,8 @@ async function configureMikroTik(config = {}) {
     return configureController(config);
   } else if (role === 'cap') {
     return configureCap(config);
+  } else if (role === 'router') {
+    return configureRouter(config);
   }
 
   // Default: standalone mode (existing behavior)

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -15,6 +15,7 @@ const {
   configureSyslog
 } = require('./infrastructure');
 const { configureController, configureCap } = require('./capsman');
+const { detectBandToken } = require('./wifi-config');
 const { configureRouter } = require('./router');
 
 /**
@@ -556,8 +557,8 @@ async function configureMikroTik(config = {}) {
 
       const commands = [];
 
-      // Ensure correct band is set
-      commands.push('channel.band=2ghz-ax');
+      // Ensure correct band is set, matching what this radio actually supports
+      commands.push(`channel.band=${await detectBandToken(mt, wifiPath, interface24, '2.4GHz')}`);
 
       // Channel configuration
       if (config24.channel !== undefined) {
@@ -608,7 +609,7 @@ async function configureMikroTik(config = {}) {
       const commands = [];
 
       // Ensure correct band is set (prevents issues if GUI changed it)
-      commands.push('channel.band=5ghz-ax');
+      commands.push(`channel.band=${await detectBandToken(mt, wifiPath, interface5, '5GHz')}`);
 
       // Channel configuration
       if (config5.channel !== undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,16 @@
 const { MikroTikSSH } = require('./ssh-client');
 const { configureMikroTik } = require('./configure');
 const { configureController, configureCap, configureCapInterfacesOnController, configureLocalCapFallback } = require('./capsman');
+const { configureRouter } = require('./router');
 const { backupMikroTikConfig } = require('./backup');
 const { configureAccessLists, backupAccessLists, extractHostname } = require('./access-list');
 
 module.exports = {
   // Main configuration entry point
   configureMikroTik,
+
+  // Router role (multi-WAN gateway)
+  configureRouter,
 
   // CAPsMAN-specific functions
   configureController,

--- a/lib/router.js
+++ b/lib/router.js
@@ -21,9 +21,13 @@ const {
   ensureBridgeInfrastructure,
   configureIgmpSnooping,
   configureSyslog,
+  detectWifiPackage,
   execIdempotent,
   execWithWarning
 } = require('./infrastructure');
+const { getWifiPath } = require('./utils');
+const { CHANNEL_FREQ_24GHZ, CHANNEL_FREQ_5GHZ } = require('./constants');
+const { detectRadioLayout, detectBandToken, configureWifiInterface } = require('./wifi-config');
 
 const WAN_LIST = 'WAN';
 const LAN_LIST = 'LAN';
@@ -811,7 +815,10 @@ async function removeStaleLanAddresses(mt, lan, connectedHost) {
  */
 function splitDetailRecords(output) {
   if (!output) return [];
-  return output.split(/\r?\n(?=\s*\d+\s)/).slice(1);
+  // Records start at the left margin with their index; continuation lines are
+  // indented far more. A looser split breaks on wrapped numeric lists, whose
+  // final line can look exactly like the start of a new record.
+  return output.split(/\r?\n(?=\s{0,3}\d+\s)/).slice(1);
 }
 
 /**
@@ -1071,6 +1078,144 @@ async function backupRouterConfig(mt) {
   return { lan, wan };
 }
 
+/**
+ * Configure the radios and SSIDs.
+ *
+ * A router owns an untagged LAN, so an SSID with no `vlan` joins the bridge
+ * untagged. Give an SSID a `vlan` and it is tagged, the same as the AP roles.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} config - Device configuration
+ */
+async function configureRouterWifi(mt, config) {
+  const ssids = config.ssids || [];
+  if (ssids.length === 0) {
+    console.log('\nℹ️  No SSIDs configured, radios left untouched');
+    return;
+  }
+
+  console.log('\n=== Configuring WiFi ===');
+
+  const wifiPackage = await detectWifiPackage(mt);
+  if (!wifiPackage) {
+    console.log('⚠️  No supported WiFi package, skipping WiFi');
+    console.log('    This tool needs wifi-qcom. Devices on the legacy `wireless`');
+    console.log('    package expose /interface wireless instead, which is not supported.');
+    return;
+  }
+
+  const wifiPath = getWifiPath(wifiPackage);
+  const wifiConfig = config.wifi || {};
+  const country = wifiConfig.country || 'United States';
+  const { interface24, interface5 } = await detectRadioLayout(mt);
+  const bandToInterface = { '2.4GHz': interface24, '5GHz': interface5 };
+
+  // Start from a known state so the device matches the config exactly.
+  try {
+    await mt.exec(`${wifiPath}/datapath remove [find name~"wifi"]`);
+  } catch (e) { /* none present */ }
+  try {
+    await mt.exec(`${wifiPath} remove [find master-interface]`);
+  } catch (e) { /* none present */ }
+  for (const name of ['wifi1', 'wifi2']) {
+    try {
+      await mt.exec(`${wifiPath} set [find default-name=${name}] name=${name}`);
+    } catch (e) { /* single-band device */ }
+  }
+  console.log('✓ Cleared previous virtual interfaces and datapaths');
+
+  // Band settings, using whichever band token this radio actually supports.
+  for (const band of ['2.4GHz', '5GHz']) {
+    const bandConfig = wifiConfig[band];
+    if (!bandConfig) continue;
+
+    const iface = bandToInterface[band];
+    const freqMap = band === '2.4GHz' ? CHANNEL_FREQ_24GHZ : CHANNEL_FREQ_5GHZ;
+    const commands = [`channel.band=${await detectBandToken(mt, wifiPath, iface, band)}`];
+
+    if (bandConfig.channel !== undefined && freqMap[bandConfig.channel]) {
+      commands.push(`channel.frequency=${freqMap[bandConfig.channel]}`);
+    } else if (bandConfig.frequency !== undefined) {
+      commands.push(`channel.frequency=${bandConfig.frequency}`);
+    }
+    if (bandConfig.width !== undefined) commands.push(`channel.width=${bandConfig.width}`);
+    if (bandConfig.txPower !== undefined) commands.push(`configuration.tx-power=${bandConfig.txPower}`);
+    commands.push(`configuration.country="${bandConfig.country || country}"`);
+
+    await execWithWarning(
+      mt,
+      `${wifiPath} set ${iface} ${commands.join(' ')}`,
+      `${band} band settings on ${iface}`,
+      `Could not apply ${band} settings`
+    );
+  }
+
+  // One master interface per band; extra SSIDs get virtual interfaces.
+  const bandUsage = { '2.4GHz': 0, '5GHz': 0 };
+
+  for (const ssidConfig of ssids) {
+    const { ssid, passphrase, vlan, bands } = ssidConfig;
+    if (!ssid || !passphrase || !bands || bands.length === 0) {
+      console.log(`⚠️  Skipping incomplete SSID: ${ssid || 'unnamed'}`);
+      continue;
+    }
+
+    for (const band of bands) {
+      const master = bandToInterface[band];
+      if (!master) {
+        console.log(`  ⚠️  Unknown band ${band}, skipping`);
+        continue;
+      }
+
+      const isVirtual = bandUsage[band] > 0;
+      const iface = isVirtual ? `${master}-ssid${bandUsage[band] + 1}` : master;
+      bandUsage[band]++;
+
+      try {
+        if (isVirtual) {
+          try {
+            await mt.exec(`${wifiPath} add master-interface=${master} name="${iface}"`);
+            console.log(`  ✓ Created virtual interface ${iface}`);
+            await new Promise(r => setTimeout(r, 500));
+          } catch (e) {
+            if (!/already have|exists/.test(e.message)) throw e;
+          }
+        }
+
+        // A datapath object is only needed when the SSID is tagged. Untagged
+        // SSIDs ride the bridge directly.
+        if (vlan !== undefined && vlan !== null) {
+          const datapath = `${iface}-vlan${vlan}`;
+          try {
+            await mt.exec(`${wifiPath}/datapath add name="${datapath}" vlan-id=${vlan} bridge=bridge`);
+          } catch (e) {
+            if (/already have|exists/.test(e.message)) {
+              await mt.exec(`${wifiPath}/datapath set [find name="${datapath}"] vlan-id=${vlan} bridge=bridge`);
+            } else {
+              throw e;
+            }
+          }
+        }
+
+        await configureWifiInterface(mt, wifiPath, iface, ssidConfig, country, wifiConfig[band] || {});
+      } catch (e) {
+        console.log(`  ✗ Failed to configure ${iface}: ${e.message}`);
+      }
+    }
+  }
+
+  // A radio with no SSIDs should be off, not broadcasting a stale default.
+  for (const [band, count] of Object.entries(bandUsage)) {
+    if (count > 0) continue;
+    await execWithWarning(
+      mt,
+      `${wifiPath} set ${bandToInterface[band]} disabled=yes`,
+      `Disabled ${bandToInterface[band]} (${band}) - no SSIDs configured`,
+      `Could not disable ${bandToInterface[band]}`
+    );
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /* Entry point                                                         */
 /* ------------------------------------------------------------------ */
@@ -1127,6 +1272,7 @@ async function configureRouter(config = {}) {
     }
     await configureDhcpServer(mt, lan);
     await configureDns(mt, lan);
+    await configureRouterWifi(mt, config);
     await configureSyslog(mt, config);
 
     let pending = false;
@@ -1165,6 +1311,7 @@ module.exports = {
   addLanAddress,
   removeStaleLanAddresses,
   backupRouterConfig,
+  configureRouterWifi,
   wanMemberComment,
   parseWanMemberComment
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,0 +1,1170 @@
+/**
+ * Router role configuration
+ * Multi-WAN gateway with recursive-route failover, NAT, DHCP server and DNS.
+ *
+ * Unlike the WAP roles, this role KEEPS router functions. lib/configure.js
+ * deliberately strips them (DHCP servers, NAT, static IPs, DNS) because a WAP
+ * sits behind someone else's router. A router role must do the opposite.
+ *
+ * Object ownership is expressed through comments:
+ *   - routes            "wan:<name> probe" / "wan:<name> default"
+ *   - NAT rules         "router:masquerade"
+ *   - filter rules      "router:<purpose>"
+ *   - pool / server     "router:lan"
+ * Re-applying finds objects by those comments and replaces them, so a second
+ * run is a no-op and hand-added objects are left alone.
+ */
+
+const { MikroTikSSH } = require('./ssh-client');
+const {
+  setDeviceIdentity,
+  ensureBridgeInfrastructure,
+  configureIgmpSnooping,
+  configureSyslog,
+  execIdempotent,
+  execWithWarning
+} = require('./infrastructure');
+
+const WAN_LIST = 'WAN';
+const LAN_LIST = 'LAN';
+const LAN_POOL = 'lan-pool';
+const LAN_DHCP = 'lan-dhcp';
+
+// Probe targets handed out when a WAN does not name its own.
+const DEFAULT_PROBES = ['8.8.8.8', '1.1.1.1', '9.9.9.9', '208.67.222.222'];
+
+/* ------------------------------------------------------------------ */
+/* Address helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Convert a dotted-quad IPv4 address to a 32-bit unsigned integer.
+ * @param {string} ip
+ * @returns {number|null}
+ */
+function ipToInt(ip) {
+  const parts = String(ip).trim().split('.');
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return null;
+    value = (value * 256) + octet;
+  }
+  return value >>> 0;
+}
+
+/**
+ * Convert a 32-bit unsigned integer to a dotted-quad IPv4 address.
+ * @param {number} value
+ * @returns {string}
+ */
+function intToIp(value) {
+  return [24, 16, 8, 0].map(shift => (value >>> shift) & 255).join('.');
+}
+
+/**
+ * Split "192.168.80.1/24" into its address and prefix length.
+ * @param {string} cidr
+ * @returns {{address: string, prefix: number}|null}
+ */
+function parseCidr(cidr) {
+  const match = String(cidr || '').trim().match(/^(\d+\.\d+\.\d+\.\d+)\/(\d+)$/);
+  if (!match) return null;
+  const prefix = parseInt(match[2], 10);
+  if (ipToInt(match[1]) === null || prefix < 0 || prefix > 32) return null;
+  return { address: match[1], prefix };
+}
+
+/**
+ * Test whether an address falls inside a CIDR range.
+ * Used to avoid deleting the address we are currently connected through.
+ * @param {string} ip
+ * @param {string} cidr
+ * @returns {boolean}
+ */
+function cidrContains(ip, cidr) {
+  const parsed = parseCidr(cidr);
+  const target = ipToInt(ip);
+  if (!parsed || target === null) return false;
+  const base = ipToInt(parsed.address);
+  if (parsed.prefix === 0) return true;
+  const mask = (0xFFFFFFFF << (32 - parsed.prefix)) >>> 0;
+  return ((base & mask) >>> 0) === ((target & mask) >>> 0);
+}
+
+/**
+ * Network address of a CIDR, e.g. "192.168.80.1/24" -> "192.168.80.0/24".
+ * The DHCP server network entry must be the network, not the host address.
+ * @param {string} cidr
+ * @returns {string|null}
+ */
+function networkOf(cidr) {
+  const parsed = parseCidr(cidr);
+  if (!parsed) return null;
+  const mask = parsed.prefix === 0 ? 0 : (0xFFFFFFFF << (32 - parsed.prefix)) >>> 0;
+  return `${intToIp((ipToInt(parsed.address) & mask) >>> 0)}/${parsed.prefix}`;
+}
+
+/**
+ * Derive a sensible DHCP pool from the LAN CIDR when none is configured.
+ * Uses .100 through .200 of the network for a /24 or wider.
+ * @param {string} cidr
+ * @returns {string|null}
+ */
+function defaultPoolFor(cidr) {
+  const parsed = parseCidr(cidr);
+  if (!parsed || parsed.prefix > 24) return null;
+  const mask = (0xFFFFFFFF << (32 - parsed.prefix)) >>> 0;
+  const base = (ipToInt(parsed.address) & mask) >>> 0;
+  return `${intToIp(base + 100)}-${intToIp(base + 200)}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* WAN normalisation                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Fill in defaults and ordering for the configured WAN links.
+ * Lower distance wins, so the list is sorted by distance for display.
+ * @param {Array<Object>} wanConfig
+ * @returns {Array<Object>}
+ */
+function normalizeWans(wanConfig = []) {
+  const ordered = wanConfig.map((wan, index) => ({
+    name: wan.name || `wan${index + 1}`,
+    interface: wan.interface,
+    type: wan.type || 'dhcp',
+    distance: wan.distance !== undefined ? wan.distance : index + 1,
+    probe: wan.probe,
+    apn: wan.apn,
+    address: wan.address,
+    gateway: wan.gateway,
+    user: wan.user,
+    password: wan.password
+  })).sort((a, b) => a.distance - b.distance);
+
+  // Assign default probes after sorting, so the most preferred uplink gets the
+  // first target. Assigning before would let the order they were typed in
+  // decide, which reads as arbitrary in the config that gets backed up.
+  const taken = new Set(ordered.map(w => w.probe).filter(Boolean));
+  let next = 0;
+  for (const wan of ordered) {
+    if (wan.probe) continue;
+    while (next < DEFAULT_PROBES.length && taken.has(DEFAULT_PROBES[next])) next++;
+    wan.probe = DEFAULT_PROBES[next] || DEFAULT_PROBES[DEFAULT_PROBES.length - 1];
+    taken.add(wan.probe);
+    next++;
+  }
+
+  return ordered;
+}
+
+/**
+ * Build the comment stored on a WAN interface-list member.
+ * This is how an uplink's settings survive the link being down.
+ * @param {Object} wan - One normalised WAN link
+ * @returns {string}
+ */
+function wanMemberComment(wan) {
+  const parts = [`wan:${wan.name}`, `type=${wan.type}`, `distance=${wan.distance}`, `probe=${wan.probe}`];
+  if (wan.apn) parts.push(`apn=${wan.apn}`);
+  if (wan.gateway) parts.push(`gateway=${wan.gateway}`);
+  return parts.join(' ');
+}
+
+/**
+ * Parse a WAN interface-list member comment back into settings.
+ * @param {string} comment
+ * @returns {Object|null}
+ */
+function parseWanMemberComment(comment) {
+  if (!comment) return null;
+  const nameMatch = comment.match(/^wan:(\S+)/);
+  if (!nameMatch) return null;
+
+  const link = { name: nameMatch[1] };
+  for (const [, key, value] of comment.matchAll(/(\w+)=(\S+)/g)) {
+    if (key === 'distance') {
+      const n = parseInt(value, 10);
+      if (!Number.isNaN(n)) link.distance = n;
+    } else if (['type', 'probe', 'apn', 'gateway'].includes(key)) {
+      link[key] = value;
+    }
+  }
+  return link;
+}
+
+/* ------------------------------------------------------------------ */
+/* Phases                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Maintain the WAN and LAN interface lists.
+ *
+ * RouterOS interface lists let one NAT rule and one firewall rule cover every
+ * uplink, however many there are. The device's own default config already
+ * works this way, so the router role follows the same convention.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Array<Object>} wans - Normalised WAN links
+ * @returns {boolean} - True when the LAN list contains the bridge
+ */
+async function configureInterfaceLists(mt, wans) {
+  console.log('\n=== Configuring Interface Lists ===');
+
+  for (const list of [WAN_LIST, LAN_LIST]) {
+    await execIdempotent(
+      mt,
+      `/interface list add name=${list}`,
+      `Interface list ${list} present`,
+      ['already have', 'exists']
+    );
+  }
+
+  // Rebuild membership so removed WAN links do not linger in the list.
+  for (const wan of wans) {
+    try {
+      await mt.exec(`/interface list member remove [find list=${WAN_LIST} interface=${wan.interface}]`);
+    } catch (e) { /* not a member yet */ }
+  }
+  try {
+    await mt.exec(`/interface list member remove [find list=${LAN_LIST} interface=bridge]`);
+  } catch (e) { /* not a member yet */ }
+
+  for (const wan of wans) {
+    // This comment is the authoritative record of the uplink's settings.
+    // Routes only exist while a link is up, so reading settings back from
+    // them would lose an unplugged uplink entirely. The list member is always
+    // there.
+    await execWithWarning(
+      mt,
+      `/interface list member add list=${WAN_LIST} interface=${wan.interface} ` +
+        `comment="${wanMemberComment(wan)}"`,
+      `${wan.interface} added to ${WAN_LIST} list`,
+      `Could not add ${wan.interface} to ${WAN_LIST}`
+    );
+  }
+
+  await execWithWarning(
+    mt,
+    `/interface list member add list=${LAN_LIST} interface=bridge`,
+    `bridge added to ${LAN_LIST} list`,
+    `Could not add bridge to ${LAN_LIST}`
+  );
+
+  // The input-chain drop rule trusts this list. Verify before relying on it.
+  try {
+    const members = await mt.exec(`/interface list member print where list=${LAN_LIST}`);
+    if (members.includes('bridge')) {
+      console.log(`✓ Verified: bridge is in the ${LAN_LIST} list`);
+      return true;
+    }
+    console.log(`⚠️  bridge is NOT in the ${LAN_LIST} list - firewall drop rule will be skipped`);
+    return false;
+  } catch (e) {
+    console.log(`⚠️  Could not verify ${LAN_LIST} membership: ${e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Put the LAN ports on the bridge and take the WAN ports off it.
+ * A routed uplink must not be a bridge port, or its traffic would be switched
+ * onto the LAN instead of routed.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ * @param {Array<Object>} wans - Normalised WAN links
+ */
+async function configureLanBridge(mt, lan, wans) {
+  console.log('\n=== Configuring LAN Bridge ===');
+
+  for (const wan of wans) {
+    try {
+      const existing = await mt.exec(`/interface bridge port print terse where interface=${wan.interface}`);
+      if (existing && existing.trim()) {
+        await mt.exec(`/interface bridge port remove [find interface=${wan.interface}]`);
+        console.log(`✓ Removed ${wan.interface} from bridge (it is a routed uplink)`);
+      }
+    } catch (e) {
+      console.log(`⚠️  Could not remove ${wan.interface} from bridge: ${e.message}`);
+    }
+  }
+
+  const ports = lan.ports || [];
+  for (const port of ports) {
+    await execIdempotent(
+      mt,
+      `/interface bridge port add bridge=bridge interface=${port}`,
+      `${port} on bridge`,
+      ['already have interface']
+    );
+    await execWithWarning(
+      mt,
+      `/interface ethernet set [find default-name=${port}] disabled=no`,
+      `${port} enabled`,
+      `Could not enable ${port}`
+    );
+  }
+
+  // The LAN address is static, so a DHCP client on the bridge would fight it.
+  try {
+    const clients = await mt.exec('/ip dhcp-client print terse where interface=bridge');
+    if (clients && clients.trim()) {
+      await mt.exec('/ip dhcp-client remove [find interface=bridge]');
+      console.log('✓ Removed DHCP client from bridge (LAN address is static)');
+    }
+  } catch (e) { /* none present */ }
+}
+
+/**
+ * Bring up each uplink according to its type.
+ *
+ * Every type is created with add-default-route=no and use-peer-dns=no.
+ * The tool owns the default routes and the resolver list; letting the ISP
+ * inject either would break failover in ways that are hard to see.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Array<Object>} wans - Normalised WAN links
+ */
+async function configureWanLinks(mt, wans) {
+  console.log('\n=== Configuring WAN Links ===');
+
+  for (const wan of wans) {
+    console.log(`\n--- ${wan.name} (${wan.interface}, ${wan.type}) ---`);
+
+    if (wan.type === 'dhcp') {
+      try {
+        await mt.exec(`/ip dhcp-client remove [find interface=${wan.interface}]`);
+      } catch (e) { /* none present */ }
+      await execWithWarning(
+        mt,
+        `/ip dhcp-client add interface=${wan.interface} add-default-route=no ` +
+          `use-peer-dns=no use-peer-ntp=no disabled=no comment="wan:${wan.name}"`,
+        `DHCP client on ${wan.interface}`,
+        `Could not add DHCP client on ${wan.interface}`
+      );
+      await execWithWarning(
+        mt,
+        `/interface ethernet set [find default-name=${wan.interface}] disabled=no`,
+        `${wan.interface} enabled`,
+        `Could not enable ${wan.interface}`
+      );
+
+    } else if (wan.type === 'static') {
+      if (!wan.address) {
+        console.log(`⚠️  ${wan.name}: type is static but no address given, skipping`);
+        continue;
+      }
+      try {
+        await mt.exec(`/ip address remove [find interface=${wan.interface} dynamic=no]`);
+      } catch (e) { /* none present */ }
+      await execWithWarning(
+        mt,
+        `/ip address add address=${wan.address} interface=${wan.interface} comment="wan:${wan.name}"`,
+        `Static address ${wan.address} on ${wan.interface}`,
+        `Could not set static address on ${wan.interface}`
+      );
+      await execWithWarning(
+        mt,
+        `/interface ethernet set [find default-name=${wan.interface}] disabled=no`,
+        `${wan.interface} enabled`,
+        `Could not enable ${wan.interface}`
+      );
+
+    } else if (wan.type === 'pppoe') {
+      try {
+        await mt.exec(`/interface pppoe-client remove [find name="pppoe-${wan.name}"]`);
+      } catch (e) { /* none present */ }
+      await execWithWarning(
+        mt,
+        `/interface pppoe-client add name="pppoe-${wan.name}" interface=${wan.interface} ` +
+          `user="${wan.user || ''}" password="${wan.password || ''}" ` +
+          `add-default-route=no use-peer-dns=no disabled=no comment="wan:${wan.name}"`,
+        `PPPoE client pppoe-${wan.name} on ${wan.interface}`,
+        `Could not add PPPoE client on ${wan.interface}`
+      );
+
+    } else if (wan.type === 'lte') {
+      // The APN profile carries add-default-route. Left at its default it
+      // injects a modem route that competes with the failover routes.
+      const profile = `apn-${wan.name}`;
+      const apnParams = [
+        `name="${profile}"`,
+        'add-default-route=no',
+        'use-peer-dns=no'
+      ];
+      if (wan.apn) {
+        apnParams.push(`apn="${wan.apn}"`, 'use-network-apn=no');
+      } else {
+        apnParams.push('use-network-apn=yes');
+      }
+
+      try {
+        await mt.exec(`/interface lte apn remove [find name="${profile}"]`);
+      } catch (e) { /* none present */ }
+      await execWithWarning(
+        mt,
+        `/interface lte apn add ${apnParams.join(' ')}`,
+        `APN profile ${profile}${wan.apn ? ` (apn=${wan.apn})` : ' (network-supplied APN)'}`,
+        `Could not create APN profile ${profile}`
+      );
+      await execWithWarning(
+        mt,
+        `/interface lte set [find name=${wan.interface}] apn-profiles="${profile}" disabled=no`,
+        `${wan.interface} using ${profile}`,
+        `Could not attach APN profile to ${wan.interface}`
+      );
+
+    } else {
+      console.log(`⚠️  ${wan.name}: unknown type "${wan.type}", skipping`);
+    }
+  }
+}
+
+/**
+ * Find the next hop for one uplink.
+ *
+ * Point-to-point links (LTE, PPPoE) have no useful gateway address, so the
+ * interface name is used directly. DHCP leases carry a gateway that has to be
+ * read back from the device after the lease binds.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} wan - One normalised WAN link
+ * @returns {string|null} - Gateway address or interface name
+ */
+async function resolveWanGateway(mt, wan) {
+  if (wan.type === 'lte') return wan.interface;
+  if (wan.type === 'pppoe') return `pppoe-${wan.name}`;
+  if (wan.type === 'static') return wan.gateway || null;
+
+  try {
+    const detail = await mt.exec(`/ip dhcp-client print detail where interface=${wan.interface}`);
+    const match = detail.match(/gateway=(\d+\.\d+\.\d+\.\d+)/);
+    if (match) return match[1];
+    console.log(`⚠️  ${wan.name}: DHCP lease has no gateway yet (is the cable connected?)`);
+  } catch (e) {
+    console.log(`⚠️  ${wan.name}: could not read DHCP gateway: ${e.message}`);
+  }
+  return null;
+}
+
+/**
+ * Write the recursive failover routes.
+ *
+ * Each uplink gets a probe route pinning one address to that uplink, plus a
+ * default route whose gateway is that probe address. RouterOS resolves the
+ * default route through the probe route, and check-gateway=ping tests the
+ * whole path to the internet rather than just the first hop. A modem that has
+ * lost its uplink still answers pings on its LAN side, which is exactly the
+ * failure a first-hop check misses.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Array<Object>} wans - Normalised WAN links
+ */
+async function configureFailoverRoutes(mt, wans) {
+  console.log('\n=== Configuring Failover Routes ===');
+
+  try {
+    await mt.exec('/ip route remove [find comment~"^wan:"]');
+    console.log('✓ Cleared previously managed routes');
+  } catch (e) { /* none present */ }
+
+  for (const wan of wans) {
+    const gateway = await resolveWanGateway(mt, wan);
+    if (!gateway) {
+      console.log(`⚠️  ${wan.name}: no gateway available, routes skipped`);
+      console.log('    Re-run apply once the link is up to add them.');
+      continue;
+    }
+
+    await execWithWarning(
+      mt,
+      `/ip route add dst-address=${wan.probe}/32 gateway=${gateway} scope=10 ` +
+        `comment="wan:${wan.name} probe"`,
+      `${wan.name}: probe ${wan.probe} pinned to ${gateway}`,
+      `${wan.name}: could not add probe route`
+    );
+
+    await execWithWarning(
+      mt,
+      `/ip route add dst-address=0.0.0.0/0 gateway=${wan.probe} target-scope=11 ` +
+        `distance=${wan.distance} check-gateway=ping comment="wan:${wan.name} default"`,
+      `${wan.name}: default route via ${wan.probe} at distance ${wan.distance}`,
+      `${wan.name}: could not add default route`
+    );
+  }
+}
+
+/**
+ * Masquerade traffic leaving any uplink.
+ * One rule covers every WAN because it matches the interface list.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ */
+async function configureNat(mt) {
+  console.log('\n=== Configuring NAT ===');
+
+  try {
+    await mt.exec('/ip firewall nat remove [find comment~"^router:"]');
+  } catch (e) { /* none present */ }
+  try {
+    await mt.exec('/ip firewall nat remove [find comment~"^defconf"]');
+    console.log('✓ Removed default-config NAT rules (this role owns NAT now)');
+  } catch (e) { /* none present */ }
+
+  await execWithWarning(
+    mt,
+    `/ip firewall nat add chain=srcnat action=masquerade out-interface-list=${WAN_LIST} ` +
+      'comment="router:masquerade"',
+    `Masquerade on every interface in the ${WAN_LIST} list`,
+    'Could not add masquerade rule'
+  );
+}
+
+/**
+ * Build the input and forward chains.
+ *
+ * Order is deliberate. Everything that accepts management traffic is added
+ * before the rule that drops it, so no partially applied state can lock the
+ * device out. The drop rule is added last, and only after the LAN list has
+ * been verified to contain the bridge.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {boolean} lanListVerified - Whether the LAN list contains the bridge
+ * @param {boolean} fasttrack - Whether to enable fasttrack forwarding
+ */
+async function configureRouterFirewall(mt, lanListVerified, fasttrack) {
+  console.log('\n=== Configuring Firewall ===');
+
+  try {
+    await mt.exec('/ip firewall filter remove [find comment~"^router:"]');
+  } catch (e) { /* none present */ }
+  try {
+    await mt.exec('/ip firewall filter remove [find comment~"^defconf"]');
+    console.log('✓ Removed default-config filter rules (this role owns the firewall now)');
+  } catch (e) { /* none present */ }
+
+  const rules = [
+    ['chain=input action=accept connection-state=established,related,untracked',
+      'router:input-established'],
+    ['chain=input action=drop connection-state=invalid',
+      'router:input-invalid'],
+    ['chain=input action=accept protocol=icmp',
+      'router:input-icmp'],
+    [`chain=input action=accept in-interface-list=${LAN_LIST}`,
+      'router:input-lan']
+  ];
+
+  for (const [rule, comment] of rules) {
+    await execWithWarning(
+      mt,
+      `/ip firewall filter add ${rule} comment="${comment}"`,
+      comment,
+      `Could not add ${comment}`
+    );
+  }
+
+  // Management is now explicitly accepted, so dropping the rest is safe.
+  if (lanListVerified) {
+    await execWithWarning(
+      mt,
+      `/ip firewall filter add chain=input action=drop in-interface-list=!${LAN_LIST} ` +
+        'comment="router:input-drop-wan"',
+      'router:input-drop-wan (management reachable from LAN only)',
+      'Could not add input drop rule'
+    );
+  } else {
+    console.log('⚠️  Skipped the input drop rule - LAN list could not be verified');
+    console.log('    The router is left open on its uplinks. Fix the LAN list and re-apply.');
+  }
+
+  if (fasttrack) {
+    await execWithWarning(
+      mt,
+      '/ip firewall filter add chain=forward action=fasttrack-connection hw-offload=yes ' +
+        'connection-state=established,related comment="router:forward-fasttrack"',
+      'router:forward-fasttrack',
+      'Could not add fasttrack rule'
+    );
+  } else {
+    console.log('ℹ️  Fasttrack off. Fasttracked flows skip connection tracking, which');
+    console.log('   slows down how quickly stale sessions clear after a failover.');
+  }
+
+  const forwardRules = [
+    ['chain=forward action=accept connection-state=established,related,untracked',
+      'router:forward-established'],
+    ['chain=forward action=drop connection-state=invalid',
+      'router:forward-invalid'],
+    [`chain=forward action=drop connection-state=new connection-nat-state=!dstnat in-interface-list=${WAN_LIST}`,
+      'router:forward-drop-wan']
+  ];
+
+  for (const [rule, comment] of forwardRules) {
+    await execWithWarning(
+      mt,
+      `/ip firewall filter add ${rule} comment="${comment}"`,
+      comment,
+      `Could not add ${comment}`
+    );
+  }
+}
+
+/**
+ * Serve DHCP to the LAN.
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ */
+async function configureDhcpServer(mt, lan) {
+  const dhcp = lan.dhcpServer;
+  if (!dhcp) {
+    console.log('\nℹ️  No lan.dhcpServer block, DHCP server not configured');
+    return;
+  }
+
+  console.log('\n=== Configuring DHCP Server ===');
+
+  const network = networkOf(lan.address);
+  const gateway = parseCidr(lan.address).address;
+  const ranges = dhcp.pool || defaultPoolFor(lan.address);
+  const leaseTime = dhcp.leaseTime || '12h';
+  const dnsServers = (dhcp.dns && dhcp.dns.length) ? dhcp.dns.join(',') : gateway;
+
+  if (!ranges) {
+    console.log('⚠️  Could not determine a DHCP pool, skipping DHCP server');
+    return;
+  }
+
+  // The default config ships its own server and pool on the same bridge.
+  // Two servers on one interface is undefined behaviour, so remove those.
+  for (const cmd of [
+    '/ip dhcp-server remove [find comment~"^defconf"]',
+    '/ip dhcp-server remove [find name="defconf"]',
+    '/ip dhcp-server network remove [find comment~"^defconf"]',
+    '/ip pool remove [find name="default-dhcp"]'
+  ]) {
+    try { await mt.exec(cmd); } catch (e) { /* not present */ }
+  }
+
+  // Update in place rather than remove and re-add. Removing a DHCP server
+  // discards its lease table, so a second apply would drop every lease the
+  // router had handed out.
+  const upsert = async (findCmd, addCmd, setCmd, label) => {
+    let exists = false;
+    try {
+      const found = await mt.exec(findCmd);
+      exists = Boolean(found && found.trim());
+    } catch (e) { /* treat as absent */ }
+
+    await execWithWarning(mt, exists ? setCmd : addCmd, `${label}${exists ? ' (updated)' : ''}`, `Could not configure ${label}`);
+  };
+
+  await upsert(
+    `/ip pool print terse where name="${LAN_POOL}"`,
+    `/ip pool add name=${LAN_POOL} ranges=${ranges}`,
+    `/ip pool set [find name="${LAN_POOL}"] ranges=${ranges}`,
+    `Pool ${LAN_POOL}: ${ranges}`
+  );
+
+  await upsert(
+    `/ip dhcp-server print terse where name="${LAN_DHCP}"`,
+    `/ip dhcp-server add name=${LAN_DHCP} interface=bridge address-pool=${LAN_POOL} ` +
+      `lease-time=${leaseTime} disabled=no comment="router:lan"`,
+    `/ip dhcp-server set [find name="${LAN_DHCP}"] interface=bridge address-pool=${LAN_POOL} ` +
+      `lease-time=${leaseTime} disabled=no comment="router:lan"`,
+    `DHCP server ${LAN_DHCP} on bridge (lease ${leaseTime})`
+  );
+
+  await upsert(
+    `/ip dhcp-server network print terse where comment="router:lan"`,
+    `/ip dhcp-server network add address=${network} gateway=${gateway} ` +
+      `dns-server=${dnsServers} comment="router:lan"`,
+    `/ip dhcp-server network set [find comment="router:lan"] address=${network} ` +
+      `gateway=${gateway} dns-server=${dnsServers}`,
+    `DHCP network ${network} (gateway ${gateway}, DNS ${dnsServers})`
+  );
+}
+
+/**
+ * Point the router at fixed resolvers.
+ *
+ * This matters more than it looks. If the router keeps the resolvers its ISP
+ * handed out, then after a failover it still points at servers it can no
+ * longer reach. Routing works, every lookup times out, and it reads as a
+ * failed failover.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ */
+async function configureDns(mt, lan) {
+  const dns = lan.dns;
+  if (!dns || !dns.servers || dns.servers.length === 0) {
+    console.log('\nℹ️  No lan.dns.servers block, DNS left unchanged');
+    return;
+  }
+
+  console.log('\n=== Configuring DNS ===');
+
+  const allowRemote = dns.allowRemoteRequests === false ? 'no' : 'yes';
+  await execWithWarning(
+    mt,
+    `/ip dns set servers=${dns.servers.join(',')} allow-remote-requests=${allowRemote}`,
+    `Resolvers ${dns.servers.join(', ')} (allow-remote-requests=${allowRemote})`,
+    'Could not configure DNS'
+  );
+}
+
+/**
+ * Put the configured LAN address on the bridge.
+ *
+ * Adding is safe on its own, so it happens early: the DHCP server and its
+ * network entry need this address to exist before they mean anything. The old
+ * address stays for now. Removing it is the risky half, and that is deferred
+ * to removeStaleLanAddresses() at the very end.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ * @returns {boolean} - True when the address is present
+ */
+async function addLanAddress(mt, lan) {
+  console.log('\n=== Adding LAN Address ===');
+
+  const desired = lan.address;
+
+  try {
+    const existing = await mt.exec('/ip address print terse where interface=bridge');
+    if (existing.includes(desired.split('/')[0] + '/')) {
+      console.log(`✓ ${desired} already on bridge`);
+      return true;
+    }
+    await mt.exec(`/ip address add address=${desired} interface=bridge comment="router:lan"`);
+    console.log(`✓ Added ${desired} to bridge`);
+    return true;
+  } catch (e) {
+    if (e.message.includes('already have')) {
+      console.log(`✓ ${desired} already on bridge`);
+      return true;
+    }
+    console.log(`✗ Could not add ${desired}: ${e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Drop bridge addresses that are not the configured one.
+ *
+ * This runs last, and it refuses to remove the address carrying the current
+ * session. So the first run leaves both addresses in place and stays
+ * reachable; a second run, made over the new address, clears the old one.
+ * There is never a moment when the device has no reachable address.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ * @param {string} connectedHost - Address this session connected to
+ * @returns {boolean} - True when a stale address is still waiting for removal
+ */
+async function removeStaleLanAddresses(mt, lan, connectedHost) {
+  console.log('\n=== Removing Stale LAN Addresses ===');
+
+  const desired = lan.address;
+  let pending = false;
+
+  try {
+    const detail = await mt.exec('/ip address print detail where interface=bridge');
+    const found = [...detail.matchAll(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/g)].map(m => m[1]);
+
+    for (const addr of found) {
+      if (addr === desired) continue;
+
+      if (connectedHost && cidrContains(connectedHost, addr)) {
+        pending = true;
+        console.log(`ℹ️  Keeping ${addr} - this session is connected through it`);
+        console.log(`    Reconnect at ${desired.split('/')[0]} and apply again to remove it.`);
+        continue;
+      }
+
+      try {
+        await mt.exec(`/ip address remove [find address="${addr}" interface=bridge]`);
+        console.log(`✓ Removed stale address ${addr}`);
+      } catch (e) {
+        console.log(`⚠️  Could not remove ${addr}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not audit bridge addresses: ${e.message}`);
+  }
+
+  return pending;
+}
+
+/* ------------------------------------------------------------------ */
+/* Backup                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Split RouterOS "print detail" output into one string per record.
+ * Records begin with an index number; continuation lines are indented.
+ * @param {string} output
+ * @returns {Array<string>}
+ */
+function splitDetailRecords(output) {
+  if (!output) return [];
+  return output.split(/\r?\n(?=\s*\d+\s)/).slice(1);
+}
+
+/**
+ * Read the ";;; comment" RouterOS prints above each record.
+ * Detail output does not render comments as comment="..." the way terse does,
+ * which is easy to get wrong.
+ * @param {string} record
+ * @returns {string|null}
+ */
+function recordComment(record) {
+  const match = record.match(/;;;\s*([^\r\n]+)/);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Read a router configuration back off a device.
+ *
+ * The comments written during apply are what make this possible. Without them
+ * there is no way to tell a route this tool owns from one a person added by
+ * hand. lib/access-list.js reads its rules back the same way.
+ *
+ * The role is detected from the masquerade rule rather than from the routes.
+ * Routes only exist while an uplink is up, so a router whose links are all
+ * down would otherwise read back as "not a router" and lose its whole config.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @returns {Promise<Object|null>} - {lan, wan} or null if this is not a router
+ */
+async function backupRouterConfig(mt) {
+  try {
+    const nat = await mt.exec('/ip firewall nat print terse where comment="router:masquerade"');
+    if (!nat || !nat.includes('router:masquerade')) return null;
+  } catch (e) {
+    return null;
+  }
+
+  console.log('\n=== Reading Router Configuration ===');
+
+  const links = new Map();
+  const linkFor = (name) => {
+    if (!links.has(name)) links.set(name, { name });
+    return links.get(name);
+  };
+
+  // The WAN list members are the authoritative record. They exist whether or
+  // not the link is currently up.
+  try {
+    const memberOut = await mt.exec(
+      `/interface list member print detail without-paging where list=${WAN_LIST}`
+    );
+    for (const record of splitDetailRecords(memberOut)) {
+      const parsed = parseWanMemberComment(recordComment(record));
+      if (!parsed) continue;
+      const iface = record.match(/interface=(\S+)/);
+      Object.assign(linkFor(parsed.name), parsed, iface ? { interface: iface[1] } : {});
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read ${WAN_LIST} list members: ${e.message}`);
+  }
+
+  // Routes confirm the probe target and failover order for links that are up.
+  try {
+    const routeOut = await mt.exec('/ip route print detail without-paging where comment~"^wan:"');
+    for (const record of splitDetailRecords(routeOut)) {
+      const comment = recordComment(record);
+      const match = comment && comment.match(/^wan:(\S+)\s+(probe|default)$/);
+      if (!match) continue;
+      const link = linkFor(match[1]);
+
+      if (match[2] === 'probe') {
+        const dst = record.match(/dst-address=(\d+\.\d+\.\d+\.\d+)\/32/);
+        if (dst && !link.probe) link.probe = dst[1];
+        const gw = record.match(/gateway=(\S+)/);
+        if (gw && !link.gateway) link.gateway = gw[1];
+      } else {
+        const dist = record.match(/distance=(\d+)/);
+        if (dist && link.distance === undefined) link.distance = parseInt(dist[1], 10);
+      }
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read routes: ${e.message}`);
+  }
+
+  // Each uplink type leaves its own object behind, and that object is what
+  // survives when the link is down. Reading these too means an unplugged WAN
+  // still round-trips instead of quietly disappearing from the backup.
+  const sources = [
+    { cmd: '/ip dhcp-client print detail without-paging', type: 'dhcp' },
+    { cmd: '/interface pppoe-client print detail without-paging', type: 'pppoe' },
+    { cmd: '/ip address print detail without-paging', type: 'static' }
+  ];
+
+  for (const { cmd, type } of sources) {
+    let out;
+    try { out = await mt.exec(cmd); } catch (e) { continue; }
+
+    for (const record of splitDetailRecords(out)) {
+      const comment = recordComment(record);
+      const match = comment && comment.match(/^wan:(\S+)$/);
+      if (!match) continue;
+
+      const link = linkFor(match[1]);
+      if (link.type && link.interface) continue;
+      if (!link.type) link.type = type;
+
+      const iface = record.match(/interface=(\S+)/);
+      if (iface && !link.interface) link.interface = iface[1];
+      if (type === 'static') {
+        const addr = record.match(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/);
+        if (addr) link.address = addr[1];
+        const gw = record.match(/gateway=(\S+)/);
+        if (gw) link.gateway = gw[1];
+      }
+    }
+  }
+
+  // Whatever is left is a point-to-point link, where the probe route's gateway
+  // is the interface itself. LTE is the usual case.
+  let lteDetail = '';
+  try { lteDetail = await mt.exec('/interface lte print detail without-paging'); } catch (e) { /* no modem */ }
+
+  for (const link of links.values()) {
+    if (link.type || !link.gateway) continue;
+
+    if (lteDetail.includes(`name="${link.gateway}"`)) {
+      link.type = 'lte';
+      link.interface = link.gateway;
+
+      // Recover the APN from the profile this interface uses. An APN left to
+      // the network is recorded as absent, matching how it is configured.
+      const profile = lteDetail.match(
+        new RegExp(`name="${link.gateway}"[\\s\\S]*?apn-profiles=(\\S+)`)
+      );
+      if (profile) {
+        try {
+          const apnOut = await mt.exec(
+            `/interface lte apn print detail without-paging where name="${profile[1].replace(/"/g, '')}"`
+          );
+          const apn = apnOut.match(/apn="([^"]*)"/);
+          if (apn && apn[1] && !/use-network-apn=yes/.test(apnOut)) link.apn = apn[1];
+        } catch (e) { /* profile gone */ }
+      }
+    } else {
+      link.type = 'static';
+      link.interface = link.gateway;
+    }
+  }
+
+  const wan = [...links.values()]
+    .sort((a, b) => (a.distance === undefined ? 99 : a.distance) - (b.distance === undefined ? 99 : b.distance))
+    .map(link => {
+      const entry = { name: link.name, interface: link.interface, type: link.type };
+      if (link.distance !== undefined) entry.distance = link.distance;
+      if (link.probe) entry.probe = link.probe;
+      if (link.apn) entry.apn = link.apn;
+      if (link.address) entry.address = link.address;
+      if (link.type === 'static' && link.gateway) entry.gateway = link.gateway;
+      return entry;
+    });
+
+  for (const link of wan) {
+    const dist = link.distance !== undefined ? link.distance : 'unset';
+    const probe = link.probe || 'unset (link was down)';
+    console.log(`✓ Uplink ${link.name}: ${link.interface} (${link.type}), distance ${dist}, probe ${probe}`);
+  }
+
+  const lan = {};
+
+  // LAN address: prefer the one this tool wrote, else any static bridge address.
+  try {
+    const addrOut = await mt.exec('/ip address print detail without-paging where interface=bridge');
+    const records = splitDetailRecords(addrOut);
+    const owned = records.find(r => recordComment(r) === 'router:lan');
+    const pick = owned || records.find(r => !/^\s*\d+\s+\S*D/.test(r));
+    const match = (pick || '').match(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/);
+    if (match) {
+      lan.address = match[1];
+      console.log(`✓ LAN address: ${lan.address}`);
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read LAN address: ${e.message}`);
+  }
+
+  // LAN ports: bridge members that are not uplinks.
+  try {
+    const wanIfaces = new Set(wan.map(w => w.interface));
+    const portsOut = await mt.exec('/interface bridge port print detail without-paging');
+    const ports = [...portsOut.matchAll(/interface=(ether\d+)/g)]
+      .map(m => m[1])
+      .filter(name => !wanIfaces.has(name));
+    lan.ports = [...new Set(ports)];
+    if (lan.ports.length) console.log(`✓ LAN ports: ${lan.ports.join(', ')}`);
+  } catch (e) {
+    console.log(`⚠️  Could not read bridge ports: ${e.message}`);
+  }
+
+  // DHCP server and its pool.
+  try {
+    const srv = await mt.exec('/ip dhcp-server print detail without-paging where comment="router:lan"');
+    if (srv && srv.includes('name=')) {
+      const dhcpServer = {};
+      const lease = srv.match(/lease-time=(\S+)/);
+      if (lease) dhcpServer.leaseTime = lease[1];
+
+      const pool = srv.match(/address-pool=(\S+)/);
+      if (pool) {
+        const poolOut = await mt.exec(`/ip pool print detail without-paging where name=${pool[1]}`);
+        const ranges = poolOut.match(/ranges=(\S+)/);
+        if (ranges) dhcpServer.pool = ranges[1];
+      }
+
+      if (Object.keys(dhcpServer).length) {
+        lan.dhcpServer = dhcpServer;
+        console.log(`✓ DHCP server: ${dhcpServer.pool || 'pool unknown'} (lease ${dhcpServer.leaseTime})`);
+      }
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read DHCP server: ${e.message}`);
+  }
+
+  // Resolvers.
+  try {
+    const dnsOut = await mt.exec('/ip dns print');
+    // RouterOS wraps a multi-server list onto unlabelled continuation lines,
+    // so collect lines until the next "label:" appears.
+    const lines = dnsOut.split(/\r?\n/);
+    const startIndex = lines.findIndex(l => /^\s*servers:/.test(l));
+    const collected = [];
+    if (startIndex !== -1) {
+      collected.push(lines[startIndex].replace(/^\s*servers:/, ''));
+      for (let i = startIndex + 1; i < lines.length; i++) {
+        if (/^\s*[\w-]+:/.test(lines[i])) break;
+        collected.push(lines[i]);
+      }
+    }
+    const list = collected.join(',').split(/[,\s]+/).filter(Boolean);
+    if (list.length) {
+      lan.dns = {
+        servers: list,
+        allowRemoteRequests: /allow-remote-requests:\s*yes/.test(dnsOut)
+      };
+      console.log(`✓ Resolvers: ${list.join(', ')}`);
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read DNS: ${e.message}`);
+  }
+
+  // Fasttrack is opt-in, so only record it when it is on.
+  try {
+    const ft = await mt.exec('/ip firewall filter print terse where comment="router:forward-fasttrack"');
+    if (ft && ft.trim()) {
+      lan.fasttrack = true;
+      console.log('✓ Fasttrack enabled');
+    }
+  } catch (e) { /* absent */ }
+
+  return { lan, wan };
+}
+
+/* ------------------------------------------------------------------ */
+/* Entry point                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Configure a device as a multi-WAN router.
+ * @param {Object} config - Device configuration with lan and wan blocks
+ * @returns {Promise<boolean>} Success status
+ */
+async function configureRouter(config = {}) {
+  const mt = new MikroTikSSH(
+    config.host || '192.168.88.1',
+    config.username || 'admin',
+    config.password || 'admin'
+  );
+
+  const lan = config.lan || {};
+  const wans = normalizeWans(config.wan || []);
+
+  try {
+    await mt.connect();
+
+    console.log('\n========================================');
+    console.log('MikroTik Router Configuration');
+    console.log('Multi-WAN with failover');
+    console.log('========================================');
+    console.log(`\nLAN: ${lan.address || 'unset'}`);
+    console.log('Uplinks, best first:');
+    for (const wan of wans) {
+      console.log(`  ${wan.distance}. ${wan.name} - ${wan.interface} (${wan.type}), probe ${wan.probe}`);
+    }
+
+    await setDeviceIdentity(mt, config);
+    await ensureBridgeInfrastructure(mt);
+    await configureIgmpSnooping(mt, config.igmpSnooping || false);
+
+    const lanListVerified = await configureInterfaceLists(mt, wans);
+    await configureLanBridge(mt, lan, wans);
+    await configureWanLinks(mt, wans);
+
+    // Give DHCP and LTE links a moment to obtain an address before their
+    // gateways are read back for the probe routes.
+    console.log('\n⏳ Waiting 10s for uplinks to obtain addresses...');
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    await configureFailoverRoutes(mt, wans);
+    await configureNat(mt);
+    await configureRouterFirewall(mt, lanListVerified, lan.fasttrack === true);
+
+    // The DHCP server and its network entry only make sense once the bridge
+    // actually holds the LAN address, so add it before they are created.
+    if (lan.address) {
+      await addLanAddress(mt, lan);
+    }
+    await configureDhcpServer(mt, lan);
+    await configureDns(mt, lan);
+    await configureSyslog(mt, config);
+
+    let pending = false;
+    if (lan.address) {
+      pending = await removeStaleLanAddresses(mt, lan, config.host);
+    }
+
+    console.log('\n========================================');
+    console.log('✓✓✓ Router Configuration Complete! ✓✓✓');
+    console.log('========================================');
+
+    if (pending) {
+      console.log('\nOne step remains.');
+      console.log(`Reconnect at ${lan.address.split('/')[0]} and apply again.`);
+      console.log('That run removes the old address and verifies the rest.');
+    }
+
+    await mt.close();
+    return true;
+  } catch (error) {
+    console.error('\n✗ Router Configuration Error:', error.message);
+    await mt.close();
+    throw error;
+  }
+}
+
+module.exports = {
+  configureRouter,
+  // exported for reuse and for tests
+  normalizeWans,
+  parseCidr,
+  cidrContains,
+  networkOf,
+  defaultPoolFor,
+  resolveWanGateway,
+  addLanAddress,
+  removeStaleLanAddresses,
+  backupRouterConfig,
+  wanMemberComment,
+  parseWanMemberComment
+};

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -34,6 +34,63 @@ async function detectRadioLayout(mt) {
   return { interface24, interface5 };
 }
 
+// Best-to-worst band token per band. A radio that predates 802.11ax has no
+// -ax token, and setting one fails outright, which is why this is detected
+// rather than assumed.
+const BAND_PREFERENCE = {
+  '2.4GHz': ['2ghz-ax', '2ghz-n', '2ghz-g', '2ghz-b'],
+  '5GHz': ['5ghz-ax', '5ghz-ac', '5ghz-n', '5ghz-a']
+};
+
+/**
+ * Work out which band token a radio actually supports.
+ *
+ * Reads the radio's advertised bands and picks the best one it lists. Falls
+ * back to the -ax token when detection fails, which is what the code did
+ * before this existed, so ax hardware behaves exactly as it always has.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {string} wifiPath - WiFi command path
+ * @param {string} interfaceName - Interface the radio is attached to
+ * @param {string} band - '2.4GHz' or '5GHz'
+ * @returns {Promise<string>} - A band token such as '5ghz-ac'
+ */
+async function detectBandToken(mt, wifiPath, interfaceName, band) {
+  const preference = BAND_PREFERENCE[band];
+  const fallback = band === '2.4GHz' ? '2ghz-ax' : '5ghz-ax';
+  if (!preference) return fallback;
+
+  try {
+    const out = await mt.exec(`${wifiPath}/radio print detail without-paging`);
+    // Records start at the left margin with their index; continuation lines are
+    // indented far more. A looser split breaks on wrapped numeric lists such as
+    // 2g-channels, whose last line can look exactly like a new record.
+    const record = out
+      .split(/\r?\n(?=\s{0,3}\d+\s)/)
+      .find(r => new RegExp(`interface=${interfaceName}(\\s|$)`).test(r));
+
+    if (!record) {
+      console.log(`⚠️  No radio found for ${interfaceName}, assuming ${fallback}`);
+      return fallback;
+    }
+
+    // Band tokens only ever appear in the bands= field, and that field wraps
+    // across lines, so scan the whole record instead of parsing the field.
+    const supported = new Set([...record.matchAll(/\b(?:2ghz|5ghz)-[a-z]+/g)].map(m => m[0]));
+    const best = preference.find(token => supported.has(token));
+
+    if (best) {
+      console.log(`  ✓ ${interfaceName} (${band}) supports ${[...supported].join(', ')} - using ${best}`);
+      return best;
+    }
+    console.log(`⚠️  ${interfaceName} lists no known ${band} band, assuming ${fallback}`);
+  } catch (e) {
+    console.log(`⚠️  Could not read radio bands: ${e.message}, assuming ${fallback}`);
+  }
+
+  return fallback;
+}
+
 /**
  * Apply WiFi channel settings for a specific band
  * @param {MikroTikSSH} mt - Connected SSH session
@@ -122,12 +179,16 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
 
   // Build configuration command
   // Uses security.ft=yes for Fast Transition (wifi-qcom)
+  // A router owns an untagged LAN, so it configures SSIDs with no vlan. The AP
+  // roles always tag, for an upstream switch to sort out.
+  const vlanClause = vlan === undefined || vlan === null ? '' : ` datapath.vlan-id=${vlan}`;
+
   let cmd = `${wifiPath} set ${interfaceName} ` +
     `configuration.ssid="${escapedSsid}" ` +
     `configuration.country="${country}" ` +
     `security.authentication-types=wpa2-psk ` +
     `security.passphrase="${escapedPassphrase}" ` +
-    `datapath.bridge=bridge datapath.vlan-id=${vlan}`;
+    `datapath.bridge=bridge${vlanClause}`;
 
   if (useFT) {
     cmd += ` security.ft=yes security.ft-over-ds=yes`;
@@ -154,7 +215,8 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
       useWNM ? `802.11v(${transitionThreshold}dBm)` : ''
     ].filter(Boolean).join(', ');
     const txPowerStatus = bandSettings.txPower !== undefined ? `, TX=${bandSettings.txPower}dBm` : '';
-    console.log(`  ✓ Configured ${interfaceName}: SSID="${ssid}", VLAN=${vlan}${roamingStatus ? `, ${roamingStatus}` : ''}${txPowerStatus}`);
+    const vlanStatus = vlan === undefined || vlan === null ? 'untagged' : `VLAN=${vlan}`;
+    console.log(`  ✓ Configured ${interfaceName}: SSID="${ssid}", ${vlanStatus}${roamingStatus ? `, ${roamingStatus}` : ''}${txPowerStatus}`);
   } catch (e) {
     console.log(`  ✗ Failed to configure ${interfaceName}: ${e.message}`);
     throw e;
@@ -537,6 +599,7 @@ async function discoverCapInterfaces(mt, wifiPath, wifiPackage) {
 }
 
 module.exports = {
+  detectBandToken,
   detectRadioLayout,
   applyBandSettings,
   configureWifiInterface,

--- a/mikrotik-no-vlan-filtering.js
+++ b/mikrotik-no-vlan-filtering.js
@@ -25,6 +25,7 @@ const lib = require('./lib');
 // Re-export all public APIs for backward compatibility
 module.exports = {
   configureMikroTik: lib.configureMikroTik,
+  configureRouter: lib.configureRouter,
   configureController: lib.configureController,
   configureCap: lib.configureCap,
   configureCapInterfacesOnController: lib.configureCapInterfacesOnController,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/router.example.yaml
+++ b/router.example.yaml
@@ -1,0 +1,148 @@
+# MikroTik Router Configuration Example (role: router)
+#
+# Use this role when the MikroTik is the gateway, not an access point.
+# It keeps NAT, DHCP, DNS and the firewall, and it fails over between
+# two or more uplinks.
+#
+# The other roles in this tool do the opposite. A standalone, controller,
+# or cap device strips router functions, because it sits behind someone
+# else's gateway. Do not mix the two on one device.
+#
+# Apply with:
+#   ./apply-config.js router.yaml
+#
+# Tested on the MikroTik Chateau LTE6 (D53G-5HacD2HnD&EG06-A), which pairs
+# five Ethernet ports with a built-in LTE modem.
+
+device:
+  host: 192.168.88.1        # factory address; change once the LAN moves
+  username: admin
+  password: admin
+
+role: router
+
+# ---------------------------------------------------------------------------
+# LAN
+# ---------------------------------------------------------------------------
+# The router owns this network. It hands out addresses and answers DNS.
+lan:
+  address: 192.168.80.1/24  # router's own address, in CIDR form
+
+  ports:                    # ports that join the LAN bridge
+    - ether2                # never list a WAN port here
+    - ether3
+    - ether4
+    - ether5
+
+  dhcpServer:
+    pool: 192.168.80.100-192.168.80.200
+    leaseTime: 12h
+    # dns: [192.168.80.1]   # what clients are told to use; defaults to the router
+
+  dns:
+    servers:                # the router's own resolvers
+      - 1.1.1.1
+      - 8.8.8.8
+    allowRemoteRequests: true   # let LAN clients resolve through the router
+
+  # Fasttrack makes forwarding faster by letting established flows skip
+  # connection tracking. That also means stale sessions linger longer after a
+  # failover. Off by default. Turn it on if throughput matters more than
+  # failover cleanliness.
+  # fasttrack: true
+
+# ---------------------------------------------------------------------------
+# WAN
+# ---------------------------------------------------------------------------
+# List every uplink. The lowest distance is preferred; the rest are standby.
+#
+# Each uplink needs its own `probe` address. The router pins that address to
+# that uplink and pings it every few seconds. If the pings stop, the uplink is
+# marked down and the next one takes over.
+#
+# Why probe a far-away address instead of the next hop: a cable modem that has
+# lost its own uplink still answers pings on its LAN side. Checking only the
+# next hop would never notice. Checking 8.8.8.8 does.
+wan:
+  - name: primary
+    interface: ether1
+    type: dhcp              # dhcp | static | pppoe | lte
+    distance: 1             # lower wins
+    probe: 8.8.8.8
+
+  - name: backup
+    interface: lte1
+    type: lte
+    distance: 2
+    probe: 1.1.1.1          # must differ from every other probe
+    # apn: fast.t-mobile.com
+    #   Leave apn out to use whatever the network supplies.
+    #   If `/interface lte monitor lte1 once` says connected but the link
+    #   carries no traffic, the APN is usually why. Check the carrier's.
+
+  # A static uplink needs both an address and a gateway:
+  # - name: fiber
+  #   interface: ether5
+  #   type: static
+  #   address: 203.0.113.10/30
+  #   gateway: 203.0.113.9
+  #   distance: 1
+  #   probe: 9.9.9.9
+
+  # A PPPoE uplink dials out over an Ethernet port:
+  # - name: dsl
+  #   interface: ether5
+  #   type: pppoe
+  #   user: myaccount@isp.example
+  #   password: secret
+  #   distance: 3
+  #   probe: 208.67.222.222
+
+# ---------------------------------------------------------------------------
+# WiFi (optional)
+# ---------------------------------------------------------------------------
+# A router with no WiFi is valid. Leave these out and the radios are untouched.
+#
+# SSIDs on a router join the untagged LAN bridge, so `vlan` is optional here.
+# Every other role requires it, because those devices tag traffic for an
+# upstream switch to sort out. This device is the upstream.
+#
+# wifi:
+#   country: United States
+#   2.4GHz:
+#     channel: 1
+#     width: 20mhz
+#   5GHz:
+#     channel: 36
+#     width: 20/40/80mhz
+#
+# ssids:
+#   - ssid: MyNetwork
+#     passphrase: secure-password-here
+#     bands:
+#       - 2.4GHz
+#       - 5GHz
+
+# ---------------------------------------------------------------------------
+# Optional extras
+# ---------------------------------------------------------------------------
+# igmpSnooping: true        # trims multicast flooding (Sonos, Chromecast)
+#
+# syslog:
+#   server: 10.0.0.100
+#   port: 514
+#   topics:
+#     - wireless
+
+# ---------------------------------------------------------------------------
+# Moving the LAN address without locking yourself out
+# ---------------------------------------------------------------------------
+# Changing lan.address cuts the session that is applying the change. The tool
+# handles this by adding before it removes.
+#
+# Run one, over the old address:
+#   the new address goes on, the old one stays, both answer.
+# Run two, over the new address:
+#   the old address is removed and the rest is verified.
+#
+# There is never a moment when the device has no reachable address.

--- a/router.example.yaml
+++ b/router.example.yaml
@@ -63,6 +63,11 @@ lan:
 # Why probe a far-away address instead of the next hop: a cable modem that has
 # lost its own uplink still answers pings on its LAN side. Checking only the
 # next hop would never notice. Checking 8.8.8.8 does.
+#
+# Two failures, two speeds (measured on a Chateau LTE6, wired to LTE):
+#   - Link goes down (cable pulled):   ~1 second. The route stops resolving.
+#   - Link up but path dead (ISP out): 20-30 seconds. Pings must time out.
+#   - Link comes back:                 ~36 seconds, waiting on DHCP to re-bind.
 wan:
   - name: primary
     interface: ether1


### PR DESCRIPTION
Adds a fourth role, `role: router`, alongside `standalone`, `controller` and `cap`. The AP roles deliberately strip router functions — `lib/configure.js` removes DHCP servers, NAT rules, static bridge IPs and DNS. This role keeps them: the device is the gateway.

Built for and verified on a MikroTik Chateau LTE6 (`D53G-5HacD2HnD&EG06-A`, RouterOS 7.18.2), pairing wired Ethernet with the built-in LTE modem.

```yaml
role: router
lan:
  address: 192.168.80.1/24
  ports: [ether2, ether3, ether4, ether5]
  dhcpServer: {pool: 192.168.80.100-192.168.80.200, leaseTime: 12h}
  dns: {servers: [1.1.1.1, 8.8.8.8], allowRemoteRequests: true}
wan:
  - {name: primary, interface: ether1, type: dhcp, distance: 1, probe: 8.8.8.8}
  - {name: backup, interface: lte1, type: lte, apn: fast.t-mobile.com, distance: 2, probe: 1.1.1.1}
```

WAN types: `dhcp`, `static`, `pppoe`, `lte`.

## Failover

Each uplink gets a probe route pinning one address to it, plus a default route whose gateway *is* that probe address, resolved recursively with `check-gateway=ping`. This catches a dead ISP behind a live modem — a modem that lost its uplink still answers pings on its LAN side, so a next-hop check never notices.

Measured on hardware, failing wired Ethernet over to LTE and back:

| What broke | Mechanism | Measured |
|---|---|---|
| Link down (cable pulled) | Next hop stops resolving; route drops out at once | **1.2 s** |
| Link up, path beyond dead | Probe pings time out: every 10 s, two consecutive failures | **20–30 s** |
| Link restored | DHCP re-binds before the probe route resolves again | **~36 s** |

RTT confirmed traffic genuinely moved: 7 ms wired, 64–96 ms on LTE, back to 6 ms. The router stayed reachable on every probe, including mid-switch.

Failover is fast, not invisible. Each uplink has its own public address, so open connections break and new ones use the live uplink.

Two settings keep it honest, applied automatically: every uplink gets `add-default-route=no` so nothing competes with the failover routes, and `use-peer-dns=no` so the router keeps reachable resolvers instead of pointing at the dead ISP's servers — otherwise routing works, every lookup times out, and it reads as a failed failover.

**Known limit:** the probe route pins the gateway learned at apply time. A dhcp/pppoe uplink returning with a *different* gateway leaves that route stale until a re-apply. Applying is idempotent, so a scheduled re-apply covers it. Did not occur in testing.

## Lockout safety

Changing `lan.address` cuts the session applying it. The role adds the new address before removing the old, and refuses to remove the address carrying the current session. First run leaves both live; a second run over the new address clears the old. Never a moment with no reachable address. Both runs exercised on hardware.

The firewall is built accept-first, and the input drop rule is skipped entirely if the LAN list cannot be verified to contain `bridge`.

## Bugs fixed along the way

Found while testing on an 802.11ac radio; all four affect existing roles too:

- **Band token hardcoded to 802.11ax.** `channel.band=2ghz-ax`/`5ghz-ax` fails outright on any pre-ax radio. `detectBandToken()` reads the radio's advertised bands and picks the best supported, falling back to `-ax` so ax hardware is unaffected. Test radio resolves to `2ghz-n` and `5ghz-ac`.
- **`country` never round-tripped, on any role.** RouterOS prints it unquoted despite the space (`.country=United States`); the quoted-only regex silently matched nothing.
- **Untagged SSIDs dropped from backups.** The reader required a datapath with a VLAN.
- **Detail-record splitting broke on wrapped numeric lists.** `\n(?=\s*\d+\s)` also matches the last line of `2g-channels=...,\n   2472`, cutting records in half.

## Backup

Detects a router by its `router:masquerade` NAT rule — not by routes, which only exist while a link is up. Each uplink's settings live in its `WAN` interface-list member comment, so an unplugged uplink still round-trips. Verified exact for `lan`, `wan`, `wifi` and `ssids` together, both with a WAN cable unplugged and with both uplinks live.

DHCP server, pool and network are updated in place; removing a DHCP server discards its lease table. Verified a seeded lease survives re-apply.

## Validation

Rejected before touching the device: malformed `lan.address`, empty `wan`, unknown type, `static` with no address/gateway, duplicate distances, duplicate probe addresses (which would silently break the recursive lookup), and an interface listed as both WAN and LAN port. `ssids` and each SSID's `vlan` are optional for this role only.

## Note for reviewers

The test device shipped the legacy `wireless` package, not wifi-qcom, so router-role WiFi needed a package migration (`wifi-qcom-ac`). The procedure and its disk-space constraint are recorded in `CLAUDE.md`. No code depends on that migration — it only affects which hardware can run WiFi in this role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhqvP2dpczufSBaNkz67pa