### PR TITLE
Correct the release process documented in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,13 +384,22 @@ const BAND_TO_INTERFACE = {
 3. Commit with version message
 4. Create git tag: `git tag -a vX.Y.Z -m "description"`
 5. Push: `git push origin main && git push origin vX.Y.Z`
-6. GitHub Actions automatically builds/publishes Docker image to `ghcr.io/nickborgers/mikrotik-as-wap-configurator`
+6. Create the GitHub release object, which is what publishes the image:
+   `gh release create vX.Y.Z --title "vX.Y.Z - Short Description" --notes "..."`
+
+**Pushing the tag publishes nothing.** `.github/workflows/publish.yml` triggers on
+`release: published`, not on tag push. Step 6 is the step that builds and pushes the
+Docker image. A tag with no release leaves the previous image sitting at `:latest`.
+The workflow can also be run by hand via `workflow_dispatch`.
+
+Release title convention: `vX.Y.Z - Short Description`.
 
 ### Docker Image
 
 - Multi-stage build with Node.js Alpine
-- Entrypoint: `docker-entrypoint.sh` handles help/example/apply
-- Published to Docker Hub on git tag push
+- Entrypoint: `docker-entrypoint.sh` handles help/example/example-multiple/example-router/apply
+- Published to the GitHub Container Registry, `ghcr.io/nickborgers/mikrotik-as-wap-configurator`, when a GitHub release is published (NOT Docker Hub, and NOT on tag push)
+- Image tags come from the git tag with the leading `v` stripped, via `docker/metadata-action` semver patterns: `6.1.0`, `6.1`, `6`, plus `latest`. Pull `:6.1.0`, not `:v6.1.0`
 - Multi-arch: linux/amd64, linux/arm64
 - Volume mount: `/config/config.yaml`
 


### PR DESCRIPTION
Found while cutting v6.1.0. The documented release process is wrong in a way that fails silently.

## The problem

`CLAUDE.md` step 6 said:

> 6. GitHub Actions automatically builds/publishes Docker image to `ghcr.io/nickborgers/mikrotik-as-wap-configurator`

listed immediately after `git push origin vX.Y.Z`, which reads as "the tag push triggers it". It doesn't. `.github/workflows/publish.yml` triggers on:

```yaml
on:
  release:
    types: [published]
  workflow_dispatch:
```

A tag with no release object builds nothing, and `:latest` silently keeps pointing at the previous version. Anyone following the steps literally would push a tag, see no new image, and have no obvious reason why.

This did not affect v6.1.0 — a release object was created, which is what fired the build.

## Two more errors in the Docker Image section

- It said **"Published to Docker Hub on git tag push"**. The workflow only ever pushes to `ghcr.io`; Docker Hub appears nowhere in it. Same wrong trigger repeated.
- The entrypoint command list was missing `example-router`.

## Changes

- Step 6 is now the `gh release create` command, with an explicit callout that the tag alone publishes nothing
- Notes `workflow_dispatch` as the manual fallback
- Records the release title convention already used by every existing release
- Docker Image section: GHCR not Docker Hub, release-published not tag-push
- Documents that image tags come from `docker/metadata-action` semver patterns with the leading `v` stripped, so the pull tag is `:6.1.0` and **not** `:v6.1.0` — a real trip hazard given the git tag is `v6.1.0`
- Entrypoint list updated

Docs only. No code, no behaviour change.

## Verification

Every claim was checked against `.github/workflows/publish.yml`: the `release: published` trigger, the `ghcr.io` registry, `workflow_dispatch`, the multi-arch platforms, and the absence of any Docker Hub reference. The `example-router` command was confirmed present in `docker-entrypoint.sh`, and confirmed working from the published `:6.1.0` image.

## Unrelated observation, not changed here

The v6.0.0 release used the bare tag `6.0.0`, while v5.x and now v6.1.0 use the `v` prefix that `CLAUDE.md` documents. Left alone since retagging a published release is disruptive, but worth knowing the inconsistency exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhqvP2dpczufSBaNkz67pa