### PR TITLE
Fix command injection and lockout paths in the router role (v6.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,127 @@
 # Changelog
 
+## [6.1.2] - 2026-08-23 - Command Injection and Lockout Fixes
+
+Fixes fourteen findings from a second, independent adversarial review (Codex)
+of the router role. Two were Critical and six High. **Anyone running v6.1.0 or
+v6.1.1 with `role: router` should upgrade.**
+
+### Security — command injection via configuration values (Critical)
+
+Every value from a YAML config was interpolated raw into RouterOS CLI command
+strings. `escapeMikroTik()` existed in `lib/utils.js` but was not imported or
+used anywhere in `lib/router.js`.
+
+This had two consequences. The mundane one: a legitimate value containing a
+quote or a dollar sign — an ISP PPPoE password is the obvious case — produced a
+malformed command that failed or configured the wrong object. The serious one:
+a crafted value could close the quoted string and append further commands,
+which RouterOS runs with the SSH account's full privileges.
+
+```
+# before, with password: pa"ss;word
+/interface pppoe-client add ... password="pa"ss;word" add-default-route=no
+```
+
+New `lib/routeros-args.js` provides one encoder used everywhere. It draws the
+distinction that matters: quoted arguments are escaped with `q()`, while
+unquoted ones (interface names, addresses, durations, distances) cannot be
+rescued by escaping and are instead checked against strict patterns that
+**throw** on anything unexpected. A bad value now stops the apply rather than
+being silently rewritten into something else.
+
+Applies to `lib/wifi-config.js` too, which the AP roles share.
+
+### Lockout — cleanup ran even when the new address was never added (Critical)
+
+`addLanAddress()` returned `false` on failure and `configureRouter()` ignored
+it, then ran `removeStaleLanAddresses()` anyway. Cleanup now runs only when the
+desired address is confirmed present on the device, read back after the fact.
+
+### Lockout — the firewall drop rule trusted an unverified accept rule (High)
+
+Replacement rules are added with `execWithWarning()`, which logs failures and
+continues. A failed `router:input-lan` accept therefore did not stop the
+subsequent WAN drop rule from being added, and the LAN-list check proved only
+that `bridge` was a list member. The drop rule is now added only after the
+accept rule is confirmed to exist; otherwise it is skipped and the router is
+left open on its uplinks rather than unreachable.
+
+### Ownership — cleanup deleted addresses it did not own (High)
+
+`removeStaleLanAddresses()` removed every non-desired static address on the
+bridge. A hand-added secondary or recovery address was silently deleted,
+contradicting the comment-ownership model used everywhere else. It now removes
+only addresses commented `router:lan` or the factory `defconf` address it
+replaces. Static WAN configuration likewise removed every non-dynamic address
+on the interface, and is now scoped to its own `wan:<name>` comment.
+
+### Availability — applying during an outage made the outage worse (High)
+
+All managed routes were removed up front, then recreated only for gateways
+resolvable in a single read. An uplink that was down at apply time lost its
+routes with nothing to put back. Gateways are now resolved before anything is
+removed, each uplink's routes are replaced independently, a down uplink keeps
+what it had, and an apply where no uplink resolves leaves the route table
+untouched rather than emptying it.
+
+### Correctness — an SSID could not move from tagged to untagged (High)
+
+RouterOS `set` leaves unspecified properties unchanged, so omitting the VLAN
+clause left the previous `datapath.vlan-id` in place. Untagged SSIDs now
+explicitly unset it. Because that syntax is not exercised on every RouterOS
+build and this code path configures every SSID for every role, a rejection
+falls back to the previous behaviour with a warning rather than failing the
+apply.
+
+### Validation — checks only looked at what the user typed (High/Medium)
+
+Distances and probes are filled in by `normalizeWans()`, but validation
+inspected only explicit values. An omitted distance colliding with an explicit
+one passed, as did the common case of a default probe of `8.8.8.8` alongside
+`lan.dns.servers: [8.8.8.8]`. Validation now runs against the normalized list.
+
+Also added: duplicate uplink names are rejected (names key route comments,
+PPPoE client names, APN profile names and the backup map, so a collision made
+one uplink overwrite another's objects); `CIDR_RE` checked shape only, so
+`999.999.999.999/99` passed; and `lan.ports`, `lan.dns.servers`,
+`dhcpServer.pool` and `dhcpServer.leaseTime` are now type- and
+format-checked.
+
+### Reporting — apply claimed success regardless of outcome (Medium)
+
+Phases log warnings and continue, so an apply could report "Complete" with no
+default route, no NAT, no DHCP and no LAN address. `verifyRouterState()` now
+checks the LAN address, a managed default route, the masquerade rule, the
+management accept rule and the DHCP server, and throws listing whatever is
+missing.
+
+### Backup — PPPoE passwords were silently dropped (Medium)
+
+The password was written during apply but never read back, so applying a
+generated backup reset the uplink with an empty password. It now round-trips,
+and if it cannot be read the backup says so explicitly.
+
+### Tests
+
+`test/router.test.js` grows to 38 assertions, adding command-argument safety
+(quote, dollar sign, semicolon and `[find]` injection attempts against both
+quoted and unquoted positions) and the validation gaps above.
+
+### Not verified on hardware
+
+As with v6.1.1, these are code-verified and unit-tested only. The VLAN unset
+syntax and the new postcondition checks are the two most worth confirming on a
+device.
+
+### Files
+- `lib/routeros-args.js` — new; the one place command arguments are encoded
+- `lib/router.js` — encoding throughout, ownership-scoped cleanup, route
+  reconciliation, postcondition verification, PPPoE password readback
+- `lib/wifi-config.js` — encoding, VLAN unset with fallback
+- `lib/validate-router.js` — validates normalized values, unique names, strict types
+- `test/router.test.js` — 38 assertions
+
 ## [6.1.1] - 2026-08-23 - Router Role Review Fixes
 
 Fixes from an independent adversarial review of the v6.1.0 router role. All

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 - `lib/access-list.js` - WAP locking via access-list rules
 - `lib/router.js` - Router role: multi-WAN failover, NAT, DHCP server, DNS, firewall
 - `lib/validate-router.js` - Shared router validation (used by BOTH apply entry points)
+- `lib/routeros-args.js` - Command-argument encoding/validation (use for EVERY device command value)
 - `test/router.test.js` - Router regression tests (`npm test`)
 - `router.example.yaml` - Example router configuration (multi-WAN failover)
 - `config.yaml` - Active device configuration (gitignored, contains credentials)
@@ -376,6 +377,28 @@ const BAND_TO_INTERFACE = {
 - No interface ever gets a NAMED datapath. `configureWifiInterface()` writes `datapath.bridge=... datapath.vlan-id=N` inline. Read the VLAN off the interface with `/(?:datapath)?\.vlan-id=(\d+)/` - a named-datapath lookup always returns nothing.
 - `backup.js` deletes `managementInterfaces`/`disabledInterfaces` for routers. Any consumer must guard for that; `backup-multiple-devices.js` crashed on it.
 - Run `npm test` (`test/router.test.js`) before touching parsing or validation. Its fixtures are real captured RouterOS output.
+
+**NEVER Interpolate Config Values Into Device Commands (v6.1.2)**
+- Use `lib/routeros-args.js` for EVERY value that reaches a device command. `escapeMikroTik()` alone is not enough and was not wired up at all in `lib/router.js` before v6.1.2.
+- Two contexts, two treatments:
+  - Quoted (`comment="..."`, `password="..."`): wrap with `q()`, which escapes `\`, `"` and `$`.
+  - Unquoted (`interface=ether1`, `distance=2`, `lease-time=12h`): escaping cannot help. Use `ifaceName()`, `ipv4()`, `cidr()`, `ipRange()`, `duration()`, `integer()`, `ipv4List()`. They THROW on anything unexpected - that is deliberate, a bad value must stop the apply.
+- This is not hypothetical for legitimate configs: an ISP PPPoE password containing `"` or `$` produced a malformed command.
+
+**Validate Normalized Values, Not What The User Typed**
+- `normalizeWans()` fills in `distance` and `probe`. Validating only explicit fields let an implicit default collide with an explicit one, and let the common `lan.dns: [8.8.8.8]` + default probe `8.8.8.8` case through.
+- `lib/validate-router.js` calls `normalizeWans()` and checks the result.
+
+**Router Role: Ownership and Verification Rules (v6.1.2)**
+- Delete ONLY what carries this tool's comment. `removeStaleLanAddresses()` removes just `router:lan` and the factory `defconf` address; static WAN removal is scoped to `wan:<name>`. A hand-added recovery address on the bridge must survive.
+- Never delete the old LAN address until the new one is READ BACK from the device. `addLanAddress()` returns a boolean and `configureRouter()` must honour it.
+- Never add the firewall drop rule until `router:input-lan` is confirmed present. `execWithWarning()` swallows failures, so "we issued the command" is not evidence.
+- Resolve all WAN gateways BEFORE removing any routes, and replace each uplink's routes independently. Removing everything up front made an apply during an outage strip a down uplink's routes with nothing to restore.
+- `verifyRouterState()` runs at the end and THROWS on unmet postconditions. Without it, apply reported success with no route, no NAT and no DHCP.
+
+**RouterOS `set` Does Not Clear Unspecified Properties**
+- Omitting `datapath.vlan-id` leaves the old VLAN in place, so a tagged SSID could never become untagged. Use the `!datapath.vlan-id` unset form.
+- That syntax is not confirmed across all RouterOS builds and this path configures every SSID for every role, so `configureWifiInterface()` retries without it on a syntax error rather than failing the apply.
 
 ### MikroTik RouterOS v7 WiFi Quirks
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -28,6 +28,7 @@ const {
   execWithWarning
 } = require('./infrastructure');
 const { getWifiPath } = require('./utils');
+const { q, must, ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List } = require('./routeros-args');
 const { CHANNEL_FREQ_24GHZ, CHANNEL_FREQ_5GHZ } = require('./constants');
 const { detectRadioLayout, detectBandToken, configureWifiInterface } = require('./wifi-config');
 
@@ -272,7 +273,7 @@ async function configureInterfaceLists(mt, wans) {
   } catch (e) { /* none present */ }
   for (const wan of wans) {
     try {
-      await mt.exec(`/interface list member remove [find list=${WAN_LIST} interface=${wan.interface}]`);
+      await mt.exec(`/interface list member remove [find list=${WAN_LIST} interface=${ifaceName(wan.interface)}]`);
     } catch (e) { /* not a member yet */ }
   }
   try {
@@ -286,8 +287,8 @@ async function configureInterfaceLists(mt, wans) {
     // there.
     await execWithWarning(
       mt,
-      `/interface list member add list=${WAN_LIST} interface=${wan.interface} ` +
-        `comment="${wanMemberComment(wan)}"`,
+      `/interface list member add list=${WAN_LIST} interface=${ifaceName(wan.interface)} ` +
+        `comment=${q(wanMemberComment(wan))}`,
       `${wan.interface} added to ${WAN_LIST} list`,
       `Could not add ${wan.interface} to ${WAN_LIST}`
     );
@@ -329,9 +330,9 @@ async function configureLanBridge(mt, lan, wans) {
 
   for (const wan of wans) {
     try {
-      const existing = await mt.exec(`/interface bridge port print terse where interface=${wan.interface}`);
+      const existing = await mt.exec(`/interface bridge port print terse where interface=${ifaceName(wan.interface)}`);
       if (existing && existing.trim()) {
-        await mt.exec(`/interface bridge port remove [find interface=${wan.interface}]`);
+        await mt.exec(`/interface bridge port remove [find interface=${ifaceName(wan.interface)}]`);
         console.log(`✓ Removed ${wan.interface} from bridge (it is a routed uplink)`);
       }
     } catch (e) {
@@ -343,13 +344,13 @@ async function configureLanBridge(mt, lan, wans) {
   for (const port of ports) {
     await execIdempotent(
       mt,
-      `/interface bridge port add bridge=bridge interface=${port}`,
+      `/interface bridge port add bridge=bridge interface=${ifaceName(port, 'lan.ports entry')}`,
       `${port} on bridge`,
       ['already have interface']
     );
     await execWithWarning(
       mt,
-      `/interface ethernet set [find default-name=${port}] disabled=no`,
+      `/interface ethernet set [find default-name=${ifaceName(port, 'lan.ports entry')}] disabled=no`,
       `${port} enabled`,
       `Could not enable ${port}`
     );
@@ -383,18 +384,18 @@ async function configureWanLinks(mt, wans) {
 
     if (wan.type === 'dhcp') {
       try {
-        await mt.exec(`/ip dhcp-client remove [find interface=${wan.interface}]`);
+        await mt.exec(`/ip dhcp-client remove [find interface=${ifaceName(wan.interface)}]`);
       } catch (e) { /* none present */ }
       await execWithWarning(
         mt,
-        `/ip dhcp-client add interface=${wan.interface} add-default-route=no ` +
-          `use-peer-dns=no use-peer-ntp=no disabled=no comment="wan:${wan.name}"`,
+        `/ip dhcp-client add interface=${ifaceName(wan.interface)} add-default-route=no ` +
+          `use-peer-dns=no use-peer-ntp=no disabled=no comment=${q(`wan:${wan.name}`)}`,
         `DHCP client on ${wan.interface}`,
         `Could not add DHCP client on ${wan.interface}`
       );
       await execWithWarning(
         mt,
-        `/interface ethernet set [find default-name=${wan.interface}] disabled=no`,
+        `/interface ethernet set [find default-name=${ifaceName(wan.interface)}] disabled=no`,
         `${wan.interface} enabled`,
         `Could not enable ${wan.interface}`
       );
@@ -404,31 +405,34 @@ async function configureWanLinks(mt, wans) {
         console.log(`⚠️  ${wan.name}: type is static but no address given, skipping`);
         continue;
       }
+      // Remove only the address this tool owns. Wiping every static address on
+      // the interface would take out a secondary public address or one owned by
+      // another service.
       try {
-        await mt.exec(`/ip address remove [find interface=${wan.interface} dynamic=no]`);
+        await mt.exec(`/ip address remove [find interface=${ifaceName(wan.interface)} comment=${q(`wan:${wan.name}`)}]`);
       } catch (e) { /* none present */ }
       await execWithWarning(
         mt,
-        `/ip address add address=${wan.address} interface=${wan.interface} comment="wan:${wan.name}"`,
+        `/ip address add address=${cidr(wan.address, `${wan.name} address`)} interface=${ifaceName(wan.interface)} comment=${q(`wan:${wan.name}`)}`,
         `Static address ${wan.address} on ${wan.interface}`,
         `Could not set static address on ${wan.interface}`
       );
       await execWithWarning(
         mt,
-        `/interface ethernet set [find default-name=${wan.interface}] disabled=no`,
+        `/interface ethernet set [find default-name=${ifaceName(wan.interface)}] disabled=no`,
         `${wan.interface} enabled`,
         `Could not enable ${wan.interface}`
       );
 
     } else if (wan.type === 'pppoe') {
       try {
-        await mt.exec(`/interface pppoe-client remove [find name="pppoe-${wan.name}"]`);
+        await mt.exec(`/interface pppoe-client remove [find name=${q(`pppoe-${wan.name}`)}]`);
       } catch (e) { /* none present */ }
       await execWithWarning(
         mt,
-        `/interface pppoe-client add name="pppoe-${wan.name}" interface=${wan.interface} ` +
-          `user="${wan.user || ''}" password="${wan.password || ''}" ` +
-          `add-default-route=no use-peer-dns=no disabled=no comment="wan:${wan.name}"`,
+        `/interface pppoe-client add name=${q(`pppoe-${wan.name}`)} interface=${ifaceName(wan.interface)} ` +
+          `user=${q(wan.user || '')} password=${q(wan.password || '')} ` +
+          `add-default-route=no use-peer-dns=no disabled=no comment=${q(`wan:${wan.name}`)}`,
         `PPPoE client pppoe-${wan.name} on ${wan.interface}`,
         `Could not add PPPoE client on ${wan.interface}`
       );
@@ -438,18 +442,18 @@ async function configureWanLinks(mt, wans) {
       // injects a modem route that competes with the failover routes.
       const profile = `apn-${wan.name}`;
       const apnParams = [
-        `name="${profile}"`,
+        `name=${q(profile)}`,
         'add-default-route=no',
         'use-peer-dns=no'
       ];
       if (wan.apn) {
-        apnParams.push(`apn="${wan.apn}"`, 'use-network-apn=no');
+        apnParams.push(`apn=${q(wan.apn)}`, 'use-network-apn=no');
       } else {
         apnParams.push('use-network-apn=yes');
       }
 
       try {
-        await mt.exec(`/interface lte apn remove [find name="${profile}"]`);
+        await mt.exec(`/interface lte apn remove [find name=${q(profile)}]`);
       } catch (e) { /* none present */ }
       await execWithWarning(
         mt,
@@ -459,7 +463,7 @@ async function configureWanLinks(mt, wans) {
       );
       await execWithWarning(
         mt,
-        `/interface lte set [find name=${wan.interface}] apn-profiles="${profile}" disabled=no`,
+        `/interface lte set [find name=${ifaceName(wan.interface)}] apn-profiles=${q(profile)} disabled=no`,
         `${wan.interface} using ${profile}`,
         `Could not attach APN profile to ${wan.interface}`
       );
@@ -487,7 +491,7 @@ async function resolveWanGateway(mt, wan) {
   if (wan.type === 'static') return wan.gateway || null;
 
   try {
-    const detail = await mt.exec(`/ip dhcp-client print detail where interface=${wan.interface}`);
+    const detail = await mt.exec(`/ip dhcp-client print detail where interface=${ifaceName(wan.interface)}`);
     const match = detail.match(/gateway=(\d+\.\d+\.\d+\.\d+)/);
     if (match) return match[1];
     console.log(`⚠️  ${wan.name}: DHCP lease has no gateway yet (is the cable connected?)`);
@@ -510,34 +514,57 @@ async function resolveWanGateway(mt, wan) {
  * @param {MikroTikSSH} mt - Connected SSH session
  * @param {Array<Object>} wans - Normalised WAN links
  */
+function gwArg(gateway) {
+  // A gateway is either an IPv4 next hop (DHCP, static) or a point-to-point
+  // interface name (LTE, PPPoE). Both go in unquoted, so both must be checked.
+  return /^\d/.test(gateway) ? ipv4(gateway, 'gateway') : ifaceName(gateway, 'gateway interface');
+}
+
 async function configureFailoverRoutes(mt, wans) {
   console.log('\n=== Configuring Failover Routes ===');
 
-  try {
-    await mt.exec('/ip route remove [find comment~"^wan:"]');
-    console.log('✓ Cleared previously managed routes');
-  } catch (e) { /* none present */ }
-
+  // Resolve every gateway BEFORE removing anything. Clearing the routes first
+  // and then discovering a link is down would strip that uplink's routes with
+  // nothing to put back, turning an apply during an outage into a worse outage.
+  const resolved = [];
   for (const wan of wans) {
-    const gateway = await resolveWanGateway(mt, wan);
+    resolved.push({ wan, gateway: await resolveWanGateway(mt, wan) });
+  }
+
+  const usable = resolved.filter(r => r.gateway);
+  if (usable.length === 0) {
+    console.log('✗ No uplink has a resolvable gateway, so the existing routes are left untouched.');
+    console.log('    Removing them would leave the router with no default route at all.');
+    for (const { wan } of resolved) {
+      console.log(`    ${wan.name} (${wan.interface}): no gateway - is the link up?`);
+    }
+    return;
+  }
+
+  for (const { wan, gateway } of resolved) {
     if (!gateway) {
-      console.log(`⚠️  ${wan.name}: no gateway available, routes skipped`);
-      console.log('    Re-run apply once the link is up to add them.');
+      console.log(`⚠️  ${wan.name}: no gateway available, its routes are left as they are`);
+      console.log('    Re-run apply once the link is up.');
       continue;
     }
 
+    // Replace only this uplink's routes, so a down uplink keeps whatever it had.
+    try {
+      await mt.exec(`/ip route remove [find comment~${q(`^wan:${wan.name} `)}]`);
+    } catch (e) { /* none present */ }
+
     await execWithWarning(
       mt,
-      `/ip route add dst-address=${wan.probe}/32 gateway=${gateway} scope=10 ` +
-        `comment="wan:${wan.name} probe"`,
+      `/ip route add dst-address=${ipv4(wan.probe, `${wan.name} probe`)}/32 gateway=${gwArg(gateway)} scope=10 ` +
+        `comment=${q(`wan:${wan.name} probe`)}`,
       `${wan.name}: probe ${wan.probe} pinned to ${gateway}`,
       `${wan.name}: could not add probe route`
     );
 
     await execWithWarning(
       mt,
-      `/ip route add dst-address=0.0.0.0/0 gateway=${wan.probe} target-scope=11 ` +
-        `distance=${wan.distance} check-gateway=ping comment="wan:${wan.name} default"`,
+      `/ip route add dst-address=0.0.0.0/0 gateway=${ipv4(wan.probe, `${wan.name} probe`)} target-scope=11 ` +
+        `distance=${integer(wan.distance, `${wan.name} distance`)} check-gateway=ping comment=${q(`wan:${wan.name} default`)}`,
       `${wan.name}: default route via ${wan.probe} at distance ${wan.distance}`,
       `${wan.name}: could not add default route`
     );
@@ -613,8 +640,24 @@ async function configureRouterFirewall(mt, lanListVerified, fasttrack) {
     );
   }
 
+  // Adding the drop rule is the one irreversible step here. Confirm the accept
+  // rule that keeps management reachable actually landed - execWithWarning only
+  // logs failures, so "we asked for it" is not evidence that it exists.
+  let lanAcceptPresent = false;
+  try {
+    const check = await mt.exec('/ip firewall filter print terse where comment="router:input-lan"');
+    lanAcceptPresent = Boolean(check && check.includes('router:input-lan'));
+  } catch (e) {
+    console.log(`⚠️  Could not verify the management accept rule: ${e.message}`);
+  }
+
+  if (lanListVerified && !lanAcceptPresent) {
+    console.log('⚠️  The management accept rule is missing, so the WAN drop rule will be skipped.');
+    console.log('    The router is left open on its uplinks rather than unreachable. Re-apply to fix.');
+  }
+
   // Management is now explicitly accepted, so dropping the rest is safe.
-  if (lanListVerified) {
+  if (lanListVerified && lanAcceptPresent) {
     await execWithWarning(
       mt,
       `/ip firewall filter add chain=input action=drop in-interface-list=!${LAN_LIST} ` +
@@ -718,27 +761,27 @@ async function configureDhcpServer(mt, lan) {
   };
 
   await upsert(
-    `/ip pool print terse where name="${LAN_POOL}"`,
-    `/ip pool add name=${LAN_POOL} ranges=${ranges}`,
-    `/ip pool set [find name="${LAN_POOL}"] ranges=${ranges}`,
+    `/ip pool print terse where name=${q(LAN_POOL)}`,
+    `/ip pool add name=${LAN_POOL} ranges=${ipRange(ranges, 'lan.dhcpServer.pool')}`,
+    `/ip pool set [find name=${q(LAN_POOL)}] ranges=${ipRange(ranges, 'lan.dhcpServer.pool')}`,
     `Pool ${LAN_POOL}: ${ranges}`
   );
 
   await upsert(
-    `/ip dhcp-server print terse where name="${LAN_DHCP}"`,
+    `/ip dhcp-server print terse where name=${q(LAN_DHCP)}`,
     `/ip dhcp-server add name=${LAN_DHCP} interface=bridge address-pool=${LAN_POOL} ` +
-      `lease-time=${leaseTime} disabled=no comment="router:lan"`,
-    `/ip dhcp-server set [find name="${LAN_DHCP}"] interface=bridge address-pool=${LAN_POOL} ` +
-      `lease-time=${leaseTime} disabled=no comment="router:lan"`,
+      `lease-time=${duration(leaseTime, 'lan.dhcpServer.leaseTime')} disabled=no comment="router:lan"`,
+    `/ip dhcp-server set [find name=${q(LAN_DHCP)}] interface=bridge address-pool=${LAN_POOL} ` +
+      `lease-time=${duration(leaseTime, 'lan.dhcpServer.leaseTime')} disabled=no comment="router:lan"`,
     `DHCP server ${LAN_DHCP} on bridge (lease ${leaseTime})`
   );
 
   await upsert(
     `/ip dhcp-server network print terse where comment="router:lan"`,
-    `/ip dhcp-server network add address=${network} gateway=${gateway} ` +
-      `dns-server=${dnsServers} comment="router:lan"`,
-    `/ip dhcp-server network set [find comment="router:lan"] address=${network} ` +
-      `gateway=${gateway} dns-server=${dnsServers}`,
+    `/ip dhcp-server network add address=${cidr(network, 'LAN network')} gateway=${ipv4(gateway, 'LAN gateway')} ` +
+      `dns-server=${ipv4List(dnsServers, 'DHCP dns-server')} comment="router:lan"`,
+    `/ip dhcp-server network set [find comment="router:lan"] address=${cidr(network, 'LAN network')} ` +
+      `gateway=${ipv4(gateway, 'LAN gateway')} dns-server=${ipv4List(dnsServers, 'DHCP dns-server')}`,
     `DHCP network ${network} (gateway ${gateway}, DNS ${dnsServers})`
   );
 }
@@ -766,7 +809,7 @@ async function configureDns(mt, lan) {
   const allowRemote = dns.allowRemoteRequests === false ? 'no' : 'yes';
   await execWithWarning(
     mt,
-    `/ip dns set servers=${dns.servers.join(',')} allow-remote-requests=${allowRemote}`,
+    `/ip dns set servers=${ipv4List(dns.servers, 'lan.dns.servers')} allow-remote-requests=${allowRemote}`,
     `Resolvers ${dns.servers.join(', ')} (allow-remote-requests=${allowRemote})`,
     'Could not configure DNS'
   );
@@ -799,7 +842,7 @@ async function addLanAddress(mt, lan) {
       console.log(`✓ ${desired} already on bridge`);
       return true;
     }
-    await mt.exec(`/ip address add address=${desired} interface=bridge comment="router:lan"`);
+    await mt.exec(`/ip address add address=${cidr(desired, 'lan.address')} interface=bridge comment="router:lan"`);
     console.log(`✓ Added ${desired} to bridge`);
     return true;
   } catch (e) {
@@ -839,12 +882,41 @@ async function removeStaleLanAddresses(mt, lan, connectedHost) {
     return true;
   }
 
+  // Never delete anything until the replacement is provably in place. If the
+  // add failed and we deleted anyway, the device would be left with no address
+  // on the LAN at all.
   try {
-    const detail = await mt.exec('/ip address print detail where interface=bridge');
-    const found = [...detail.matchAll(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/g)].map(m => m[1]);
+    const check = await mt.exec('/ip address print terse where interface=bridge');
+    const present = [...check.matchAll(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/g)].map(m => m[1]);
+    if (!present.includes(desired)) {
+      console.log(`✗ ${desired} is not on the bridge, so nothing will be removed.`);
+      console.log('    Fix the LAN address first, then apply again.');
+      return true;
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not confirm ${desired} is present: ${e.message}. Removing nothing.`);
+    return true;
+  }
 
-    for (const addr of found) {
+  try {
+    const detail = await mt.exec('/ip address print detail without-paging where interface=bridge');
+
+    for (const record of splitDetailRecords(detail)) {
+      const addrMatch = record.match(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/);
+      if (!addrMatch) continue;
+      const addr = addrMatch[1];
       if (addr === desired) continue;
+
+      // Only addresses this tool owns, plus the factory address it replaces,
+      // are ours to delete. A hand-added secondary or recovery address on the
+      // bridge must survive - the comment-ownership model says so everywhere
+      // else, and this used to be the one place that ignored it.
+      const comment = recordComment(record);
+      const owned = comment === 'router:lan' || (comment || '').startsWith('defconf');
+      if (!owned) {
+        console.log(`ℹ️  Leaving ${addr} alone - not managed by this tool${comment ? ` (comment: ${comment})` : ''}`);
+        continue;
+      }
 
       if (sessionIp && cidrContains(sessionIp, addr)) {
         pending = true;
@@ -854,7 +926,7 @@ async function removeStaleLanAddresses(mt, lan, connectedHost) {
       }
 
       try {
-        await mt.exec(`/ip address remove [find address="${addr}" interface=bridge]`);
+        await mt.exec(`/ip address remove [find address=${q(addr)} interface=bridge]`);
         console.log(`✓ Removed stale address ${addr}`);
       } catch (e) {
         console.log(`⚠️  Could not remove ${addr}: ${e.message}`);
@@ -998,9 +1070,15 @@ async function backupRouterConfig(mt) {
 
       const iface = record.match(/interface=(\S+)/);
       if (iface && !link.interface) link.interface = iface[1];
-      if (type === 'pppoe' && !link.user) {
-        const user = record.match(/user="?([^"\s]+)"?/);
-        if (user) link.user = user[1];
+      if (type === 'pppoe') {
+        if (!link.user) {
+          const user = record.match(/user="([^"]*)"|user=(\S+)/);
+          if (user) link.user = user[1] !== undefined ? user[1] : user[2];
+        }
+        // Without this the backup applies with an empty password and knocks
+        // the uplink offline.
+        const pass = record.match(/password="([^"]*)"|password=(\S+)/);
+        if (pass) link.password = pass[1] !== undefined ? pass[1] : pass[2];
       }
       if (type === 'static') {
         const addr = record.match(/address=(\d+\.\d+\.\d+\.\d+\/\d+)/);
@@ -1053,6 +1131,11 @@ async function backupRouterConfig(mt) {
       if (link.address) entry.address = link.address;
       if (link.type === 'static' && link.gateway) entry.gateway = link.gateway;
       if (link.user) entry.user = link.user;
+      if (link.password) entry.password = link.password;
+      if (link.type === 'pppoe' && !link.password) {
+        console.log(`⚠️  ${link.name}: could not read the PPPoE password off the device.`);
+        console.log('    Add it to the backed-up config before applying, or the uplink will be reset with an empty password.');
+      }
       return entry;
     });
 
@@ -1227,11 +1310,15 @@ async function configureRouterWifi(mt, config) {
     if (bandConfig.channel !== undefined && freqMap[bandConfig.channel]) {
       commands.push(`channel.frequency=${freqMap[bandConfig.channel]}`);
     } else if (bandConfig.frequency !== undefined) {
-      commands.push(`channel.frequency=${bandConfig.frequency}`);
+      commands.push(`channel.frequency=${integer(bandConfig.frequency, `${band} frequency`)}`);
     }
-    if (bandConfig.width !== undefined) commands.push(`channel.width=${bandConfig.width}`);
-    if (bandConfig.txPower !== undefined) commands.push(`configuration.tx-power=${bandConfig.txPower}`);
-    commands.push(`configuration.country="${bandConfig.country || country}"`);
+    if (bandConfig.width !== undefined) {
+      commands.push(`channel.width=${must(bandConfig.width, /^[0-9a-zA-Z/+-]{1,32}$/, `${band} width`)}`);
+    }
+    if (bandConfig.txPower !== undefined) {
+      commands.push(`configuration.tx-power=${integer(bandConfig.txPower, `${band} txPower`)}`);
+    }
+    commands.push(`configuration.country=${q(bandConfig.country || country)}`);
 
     await execWithWarning(
       mt,
@@ -1265,7 +1352,7 @@ async function configureRouterWifi(mt, config) {
       try {
         if (isVirtual) {
           try {
-            await mt.exec(`${wifiPath} add master-interface=${master} name="${iface}"`);
+            await mt.exec(`${wifiPath} add master-interface=${ifaceName(master)} name=${q(iface)}`);
             console.log(`  ✓ Created virtual interface ${iface}`);
             await new Promise(r => setTimeout(r, 500));
           } catch (e) {
@@ -1293,6 +1380,74 @@ async function configureRouterWifi(mt, config) {
       `Could not disable ${bandToInterface[band]}`
     );
   }
+}
+
+/**
+ * Confirm the things a router cannot work without actually exist.
+ *
+ * Most phases log a warning and continue, which is right for optional features
+ * but means an apply could previously report success with no default route, no
+ * NAT and no DHCP. Fleet automation had no way to tell a healthy router from a
+ * broken one.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ * @returns {Promise<string[]>} - Problems found, empty when healthy
+ */
+async function verifyRouterState(mt, lan) {
+  console.log('\n=== Verifying ===');
+  const problems = [];
+
+  const check = async (label, command, expect) => {
+    try {
+      const out = await mt.exec(command);
+      if (expect(out)) {
+        console.log(`✓ ${label}`);
+      } else {
+        console.log(`✗ ${label}`);
+        problems.push(label);
+      }
+    } catch (e) {
+      console.log(`✗ ${label} (${e.message})`);
+      problems.push(`${label}: ${e.message}`);
+    }
+  };
+
+  if (lan.address) {
+    await check(
+      `LAN address ${lan.address} is on the bridge`,
+      '/ip address print terse where interface=bridge',
+      out => out.includes(`address=${lan.address}`)
+    );
+  }
+
+  await check(
+    'at least one managed default route exists',
+    '/ip route print terse where dst-address=0.0.0.0/0',
+    out => /comment=wan:/.test(out)
+  );
+
+  await check(
+    'masquerade rule is present',
+    '/ip firewall nat print terse where comment="router:masquerade"',
+    out => out.includes('router:masquerade')
+  );
+
+  await check(
+    'management is accepted from the LAN',
+    '/ip firewall filter print terse where comment="router:input-lan"',
+    out => out.includes('router:input-lan')
+  );
+
+  if (lan.dhcpServer) {
+    await check(
+      'DHCP server is running on the bridge',
+      `/ip dhcp-server print terse where name=${q(LAN_DHCP)}`,
+      out => out.includes(LAN_DHCP) && !out.includes('disabled=yes')
+    );
+  }
+
+  return problems;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1346,8 +1501,9 @@ async function configureRouter(config = {}) {
 
     // The DHCP server and its network entry only make sense once the bridge
     // actually holds the LAN address, so add it before they are created.
+    let lanAddressReady = true;
     if (lan.address) {
-      await addLanAddress(mt, lan);
+      lanAddressReady = await addLanAddress(mt, lan);
     }
     await configureDhcpServer(mt, lan);
     await configureDns(mt, lan);
@@ -1355,8 +1511,21 @@ async function configureRouter(config = {}) {
     await configureSyslog(mt, config);
 
     let pending = false;
-    if (lan.address) {
+    if (lan.address && lanAddressReady) {
       pending = await removeStaleLanAddresses(mt, lan, config.host);
+    } else if (lan.address) {
+      pending = true;
+      console.log('\n⚠️  Skipping stale-address cleanup because the LAN address was not added.');
+    }
+
+    const problems = await verifyRouterState(mt, lan);
+    if (problems.length > 0) {
+      console.log('\n========================================');
+      console.log('✗ Router Configuration INCOMPLETE');
+      console.log('========================================');
+      problems.forEach(p => console.log(`  - ${p}`));
+      await mt.close();
+      throw new Error(`Router configuration finished with ${problems.length} unmet requirement(s): ${problems.join('; ')}`);
     }
 
     console.log('\n========================================');
@@ -1392,6 +1561,7 @@ module.exports = {
   backupRouterConfig,
   configureRouterWifi,
   resolveHostAddress,
+  verifyRouterState,
   wanMemberComment,
   parseWanMemberComment
 };

--- a/lib/routeros-args.js
+++ b/lib/routeros-args.js
@@ -1,0 +1,90 @@
+/**
+ * Safe construction of RouterOS command arguments.
+ *
+ * Every value that reaches a device command originates in a YAML file. Those
+ * values were previously interpolated raw, which had two consequences:
+ *
+ *   - A legitimate value containing a quote or a dollar sign - an ISP PPPoE
+ *     password, say - produced a malformed command that either failed or
+ *     configured the wrong thing.
+ *   - A crafted value could close the quoted string and append further
+ *     commands, which RouterOS would run with the SSH account's privileges.
+ *
+ * There are two distinct contexts and they need different treatment:
+ *
+ *   Quoted   `comment="..."`, `passphrase="..."` - escape and quote with q().
+ *   Unquoted `interface=ether1`, `distance=2`    - quoting is not an option,
+ *                                                  so the value must be proven
+ *                                                  to match a strict shape.
+ *
+ * Escaping cannot rescue an unquoted argument, which is why the checkers below
+ * throw rather than sanitise. A value that fails is a configuration error and
+ * should stop the apply, not be silently rewritten into something else.
+ */
+
+const { escapeMikroTik } = require('./utils');
+
+/**
+ * Render a value as a quoted, escaped RouterOS string argument.
+ * @param {*} value
+ * @returns {string} - including the surrounding quotes
+ */
+function q(value) {
+  return `"${escapeMikroTik(String(value === undefined || value === null ? '' : value))}"`;
+}
+
+/**
+ * Throw unless the value matches a pattern, for use in unquoted argument
+ * positions where escaping offers no protection.
+ *
+ * @param {*} value - Value to check
+ * @param {RegExp} pattern - Shape the value must match
+ * @param {string} what - Human-readable field name for the error
+ * @returns {string} - The value, unchanged, when it is safe
+ */
+function must(value, pattern, what) {
+  const str = String(value === undefined || value === null ? '' : value);
+  if (!pattern.test(str)) {
+    throw new Error(
+      `Unsafe or malformed ${what}: ${JSON.stringify(str)}. ` +
+      'It goes into a device command unquoted, so it must match ' + pattern
+    );
+  }
+  return str;
+}
+
+// Interface and object names. RouterOS permits more than this, but everything
+// this tool creates or references fits, and widening it widens the blast radius.
+const IDENTIFIER = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
+const IPV4 = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+const CIDR = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\/(?:3[0-2]|[12]?\d)$/;
+const IP_RANGE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)-(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+const DURATION = /^\d+[smhdw]?$/;
+const INTEGER = /^\d{1,5}$/;
+
+const ifaceName = (v, what = 'interface name') => must(v, IDENTIFIER, what);
+const ipv4 = (v, what = 'IPv4 address') => must(v, IPV4, what);
+const cidr = (v, what = 'CIDR address') => must(v, CIDR, what);
+const ipRange = (v, what = 'address range') => must(v, IP_RANGE, what);
+const duration = (v, what = 'duration') => must(v, DURATION, what);
+const integer = (v, what = 'number') => must(v, INTEGER, what);
+
+/**
+ * Validate a comma-separated list of IPv4 addresses (DNS server lists).
+ * @param {Array<string>|string} value
+ * @param {string} what
+ * @returns {string} - Comma-joined, safe to interpolate unquoted
+ */
+function ipv4List(value, what = 'address list') {
+  const items = Array.isArray(value) ? value : String(value).split(',');
+  const clean = items.map(v => String(v).trim()).filter(Boolean);
+  if (clean.length === 0) throw new Error(`Empty ${what}`);
+  clean.forEach(v => ipv4(v, what));
+  return clean.join(',');
+}
+
+module.exports = {
+  q, must,
+  ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List,
+  IDENTIFIER, IPV4, CIDR, IP_RANGE, DURATION
+};

--- a/lib/validate-router.js
+++ b/lib/validate-router.js
@@ -7,8 +7,12 @@
  * deployment was applied with no validation at all.
  */
 
+const { CIDR, IPV4, IP_RANGE, DURATION, IDENTIFIER } = require('./routeros-args');
+const { normalizeWans } = require('./router');
+
 const VALID_WAN_TYPES = ['dhcp', 'static', 'pppoe', 'lte'];
-const CIDR_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/;
+// Shape alone is not enough: 999.999.999.999/99 matched the old pattern.
+const CIDR_RE = CIDR;
 
 /**
  * Validate the lan and wan blocks of a router-role configuration.
@@ -38,14 +42,66 @@ function validateRouterConfig(config, label = 'Router') {
     return errors;
   }
 
+  if (lan.ports !== undefined && !Array.isArray(lan.ports)) {
+    errors.push(`${label}: lan.ports must be a list`);
+  }
+  if (lan.dns?.servers !== undefined && !Array.isArray(lan.dns.servers)) {
+    errors.push(`${label}: lan.dns.servers must be a list`);
+  }
+  for (const port of Array.isArray(lan.ports) ? lan.ports : []) {
+    if (!IDENTIFIER.test(String(port))) {
+      errors.push(`${label}: lan.ports entry '${port}' is not a valid interface name`);
+    }
+  }
+  for (const server of Array.isArray(lan.dns?.servers) ? lan.dns.servers : []) {
+    if (!IPV4.test(String(server))) {
+      errors.push(`${label}: lan.dns.servers entry '${server}' is not a valid IPv4 address`);
+    }
+  }
+  if (lan.dhcpServer?.pool !== undefined && !IP_RANGE.test(String(lan.dhcpServer.pool))) {
+    errors.push(`${label}: lan.dhcpServer.pool '${lan.dhcpServer.pool}' must look like 192.168.80.100-192.168.80.200`);
+  }
+  if (lan.dhcpServer?.leaseTime !== undefined && !DURATION.test(String(lan.dhcpServer.leaseTime))) {
+    errors.push(`${label}: lan.dhcpServer.leaseTime '${lan.dhcpServer.leaseTime}' must look like 12h`);
+  }
+
+  if (wans.some(w => !w || typeof w !== 'object')) {
+    errors.push(`${label}: every wan entry must be a mapping`);
+    return errors;
+  }
+
+  // Check the values that will ACTUALLY be used. Distances and probes are
+  // filled in by normalizeWans(), so validating only what the user typed let
+  // an implicit default collide with an explicit one and pass.
+  let effective = [];
+  try {
+    effective = normalizeWans(wans);
+  } catch (e) {
+    errors.push(`${label}: ${e.message}`);
+  }
+  const effectiveFor = new Map(effective.map(w => [w.name, w]));
+
   const probes = new Map();
   const distances = new Map();
   const interfaces = new Map();
-  const lanPorts = new Set(lan.ports || []);
-  const resolvers = new Set(lan.dns?.servers || []);
+  const names = new Set();
+  const lanPorts = new Set(Array.isArray(lan.ports) ? lan.ports : []);
+  const resolvers = new Set(Array.isArray(lan.dns?.servers) ? lan.dns.servers : []);
 
   wans.forEach((wan, index) => {
-    const name = wan.name || `wan[${index}]`;
+    const name = wan.name || `wan${index + 1}`;
+
+    // Names key route comments, PPPoE client names, APN profile names and the
+    // backup map. Two uplinks sharing one would overwrite each other's objects.
+    if (wan.name !== undefined) {
+      if (!IDENTIFIER.test(String(wan.name))) {
+        errors.push(`${label}: wan name '${wan.name}' must start with a letter and use only letters, digits, dot, dash or underscore`);
+      }
+      if (names.has(wan.name)) {
+        errors.push(`${label}: two uplinks are both named '${wan.name}' - names must be unique`);
+      }
+      names.add(wan.name);
+    }
 
     if (!wan.interface) {
       errors.push(`${label}: ${name} is missing interface`);
@@ -70,36 +126,57 @@ function validateRouterConfig(config, label = 'Router') {
     if (type === 'static' && !wan.gateway) {
       errors.push(`${label}: ${name} is type static but has no gateway`);
     }
+    if (type === 'static' && wan.address && !CIDR_RE.test(String(wan.address))) {
+      errors.push(`${label}: ${name} address '${wan.address}' is not valid CIDR`);
+    }
+    if (type === 'static' && wan.gateway && !IPV4.test(String(wan.gateway))) {
+      errors.push(`${label}: ${name} gateway '${wan.gateway}' is not a valid IPv4 address`);
+    }
     if (type === 'pppoe' && !wan.user) {
       errors.push(`${label}: ${name} is type pppoe but has no user`);
     }
 
-    if (wan.distance !== undefined) {
-      if (!Number.isInteger(wan.distance) || wan.distance < 1 || wan.distance > 255) {
-        errors.push(`${label}: ${name} distance must be a whole number from 1 to 255`);
-      } else if (distances.has(wan.distance)) {
-        errors.push(`${label}: ${name} and ${distances.get(wan.distance)} share distance ${wan.distance} - each uplink needs its own`);
+    if (wan.distance !== undefined && (!Number.isInteger(wan.distance) || wan.distance < 1 || wan.distance > 255)) {
+      errors.push(`${label}: ${name} distance must be a whole number from 1 to 255`);
+    }
+
+    // Compare effective distances, so an omitted one colliding with an
+    // explicit one is caught too.
+    const eff = effectiveFor.get(name);
+    const distance = eff ? eff.distance : wan.distance;
+    if (distance !== undefined) {
+      if (distances.has(distance)) {
+        errors.push(`${label}: ${name} and ${distances.get(distance)} both end up at distance ${distance} - each uplink needs its own`);
       } else {
-        distances.set(wan.distance, name);
+        distances.set(distance, name);
       }
     }
 
     // Two uplinks probing the same address would fight over one probe route,
     // and the recursive lookup would follow whichever won.
-    if (wan.probe) {
-      if (probes.has(wan.probe)) {
-        errors.push(`${label}: ${name} and ${probes.get(wan.probe)} both probe ${wan.probe} - each uplink needs its own target`);
+    if (wan.probe !== undefined && !IPV4.test(String(wan.probe))) {
+      errors.push(`${label}: ${name} probe '${wan.probe}' is not a valid IPv4 address`);
+    }
+
+    // Compare the effective probe, including one assigned by default. The
+    // common case - a default probe of 8.8.8.8 alongside lan.dns 8.8.8.8 -
+    // used to pass because only explicit probes were checked.
+    const probe = eff ? eff.probe : wan.probe;
+    if (probe) {
+      if (probes.has(probe)) {
+        errors.push(`${label}: ${name} and ${probes.get(probe)} both probe ${probe} - each uplink needs its own target`);
       } else {
-        probes.set(wan.probe, name);
+        probes.set(probe, name);
       }
 
       // A probe address is pinned to its uplink by a /32 route with no health
       // check. If that uplink is up but the path beyond it is dead, the pin
       // stays and the address is unreachable. A resolver pinned that way
       // stalls every query that picks it, right when the network is degraded.
-      if (resolvers.has(wan.probe)) {
+      if (resolvers.has(probe)) {
+        const how = wan.probe ? '' : ' (assigned by default)';
         errors.push(
-          `${label}: ${wan.probe} is both ${name}'s probe target and a lan.dns resolver. ` +
+          `${label}: ${probe} is both ${name}'s probe target${how} and a lan.dns resolver. ` +
           'The probe pins it to that uplink, so it becomes unreachable when that uplink fails. Use different addresses.'
         );
       }

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -5,6 +5,7 @@
 
 const { CHANNEL_FREQ_24GHZ, CHANNEL_FREQ_5GHZ } = require('./constants');
 const { escapeMikroTik, getWifiPath, getCapsmanPath } = require('./utils');
+const { q, integer } = require('./routeros-args');
 
 /**
  * Detect board type and return correct interface mapping for WiFi radios
@@ -181,11 +182,15 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
   // Uses security.ft=yes for Fast Transition (wifi-qcom)
   // A router owns an untagged LAN, so it configures SSIDs with no vlan. The AP
   // roles always tag, for an upstream switch to sort out.
-  const vlanClause = vlan === undefined || vlan === null ? '' : ` datapath.vlan-id=${vlan}`;
+  // RouterOS `set` leaves unspecified properties alone, so an SSID moving from
+  // tagged to untagged would silently keep its old VLAN. Clear it explicitly.
+  const vlanClause = vlan === undefined || vlan === null
+    ? ' !datapath.vlan-id'
+    : ` datapath.vlan-id=${integer(vlan, 'vlan')}`;
 
   let cmd = `${wifiPath} set ${interfaceName} ` +
     `configuration.ssid="${escapedSsid}" ` +
-    `configuration.country="${country}" ` +
+    `configuration.country=${q(country)} ` +
     `security.authentication-types=wpa2-psk ` +
     `security.passphrase="${escapedPassphrase}" ` +
     `datapath.bridge=bridge${vlanClause}`;
@@ -202,13 +207,35 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
 
   // Add txPower from band settings if specified
   if (bandSettings.txPower !== undefined) {
-    cmd += ` configuration.tx-power=${bandSettings.txPower}`;
+    cmd += ` configuration.tx-power=${integer(bandSettings.txPower, 'txPower')}`;
   }
 
   cmd += ` disabled=no`;
 
   try {
     await mt.exec(cmd);
+  } catch (e) {
+    // `!datapath.vlan-id` is the RouterOS unset form, needed so an SSID moving
+    // from tagged to untagged actually loses its VLAN. It has not been
+    // exercised on every RouterOS build this tool supports, and this function
+    // configures every SSID for every role - so if the device rejects it,
+    // fall back to the previous behaviour rather than failing the whole apply.
+    if (vlanClause === ' !datapath.vlan-id' && /syntax|expected|unknown|invalid/i.test(e.message)) {
+      console.log(`  ⚠️  This RouterOS build rejected the VLAN unset form: ${e.message.trim()}`);
+      console.log('     Retrying without it. An SSID changing from tagged to untagged may keep its old VLAN.');
+      try {
+        await mt.exec(cmd.replace(' !datapath.vlan-id', ''));
+      } catch (retryErr) {
+        console.log(`  ✗ Failed to configure ${interfaceName}: ${retryErr.message}`);
+        throw retryErr;
+      }
+    } else {
+      console.log(`  ✗ Failed to configure ${interfaceName}: ${e.message}`);
+      throw e;
+    }
+  }
+
+  try {
     const roamingStatus = [
       useFT ? '802.11r' : '',
       useRRM ? '802.11k' : '',
@@ -218,8 +245,8 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
     const vlanStatus = vlan === undefined || vlan === null ? 'untagged' : `VLAN=${vlan}`;
     console.log(`  ✓ Configured ${interfaceName}: SSID="${ssid}", ${vlanStatus}${roamingStatus ? `, ${roamingStatus}` : ''}${txPowerStatus}`);
   } catch (e) {
-    console.log(`  ✗ Failed to configure ${interfaceName}: ${e.message}`);
-    throw e;
+    // Logging only - the interface is already configured at this point.
+    console.log(`  ✓ Configured ${interfaceName}: SSID="${ssid}"`);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -139,6 +139,32 @@ test('comments render as ;;; lines, not comment="..."', () => {
   assert.strictEqual(real.match(/comment="([^"]+)"/), null, 'detail output has no comment= form');
 });
 
+console.log('\n=== Command argument safety ===');
+const args = require('../lib/routeros-args');
+test('q() neutralises a quote, so a value cannot end the string', () => {
+  // An ISP password containing a quote used to produce a malformed command;
+  // a crafted one could append further commands.
+  const out = args.q('pa"ss;word');
+  assert.strictEqual(out, '"pa\\"ss;word"');
+  assert.ok(!/[^\\]"/.test(out.slice(1, -1)), 'no unescaped quote survives inside the string');
+});
+test('q() escapes dollar signs so RouterOS does not expand them', () => {
+  assert.strictEqual(args.q('pa$$word'), '"pa\\$\\$word"');
+});
+test('unquoted positions reject anything but a plain identifier', () => {
+  assert.strictEqual(args.ifaceName('ether1'), 'ether1');
+  assert.throws(() => args.ifaceName('ether2; /ip firewall filter remove [find]'), /Unsafe or malformed/);
+  assert.throws(() => args.ifaceName('ether2 comment=x'), /Unsafe or malformed/);
+});
+test('addresses, ranges and durations are checked, not escaped', () => {
+  assert.throws(() => args.cidr('999.999.999.999/99'), /Unsafe or malformed/);
+  assert.throws(() => args.ipv4('8.8.8.8; /user add name=x'), /Unsafe or malformed/);
+  assert.throws(() => args.duration('12h; /user add name=x'), /Unsafe or malformed/);
+  assert.throws(() => args.ipRange('1.1.1.1-2.2.2.2 extra=1'), /Unsafe or malformed/);
+  assert.strictEqual(args.ipv4List(['1.1.1.1', '8.8.8.8']), '1.1.1.1,8.8.8.8');
+  assert.throws(() => args.ipv4List(['1.1.1.1', 'evil']), /Unsafe or malformed/);
+});
+
 console.log('\n=== Validation ===');
 test('accepts a well-formed config', () => {
   assert.deepStrictEqual(validateRouterConfig({
@@ -171,12 +197,49 @@ test('rejects a probe address that is also a resolver', () => {
   });
   assert.ok(e.some(x => /probe target and a lan.dns resolver/.test(x)));
 });
-test('rejects duplicate distances', () => {
+test('rejects duplicate explicit distances', () => {
   const e = validateRouterConfig({
     lan: { address: '192.168.80.1/24' },
     wan: [{ name: 'a', interface: 'e1', distance: 1 }, { name: 'b', interface: 'e2', distance: 1 }]
   });
-  assert.ok(e.some(x => /share distance/.test(x)));
+  assert.ok(e.some(x => /end up at distance/.test(x)));
+});
+test('rejects an implicit distance colliding with an explicit one', () => {
+  // 'a' has no distance, so it defaults to 1 - the same as 'b'. Checking only
+  // what the user typed let this through.
+  const e = validateRouterConfig({
+    lan: { address: '192.168.80.1/24' },
+    wan: [{ name: 'a', interface: 'e1' }, { name: 'b', interface: 'e2', distance: 1 }]
+  });
+  assert.ok(e.some(x => /end up at distance 1/.test(x)));
+});
+test('rejects a default-assigned probe that is also a resolver', () => {
+  // No explicit probe, so 'a' gets 8.8.8.8 by default - which is also the
+  // configured resolver.
+  const e = validateRouterConfig({
+    lan: { address: '192.168.80.1/24', dns: { servers: ['8.8.8.8'] } },
+    wan: [{ name: 'a', interface: 'e1' }]
+  });
+  assert.ok(e.some(x => /assigned by default/.test(x)));
+});
+test('rejects duplicate uplink names', () => {
+  const e = validateRouterConfig({
+    lan: { address: '192.168.80.1/24' },
+    wan: [{ name: 'a', interface: 'e1', distance: 1 }, { name: 'a', interface: 'e2', distance: 2 }]
+  });
+  assert.ok(e.some(x => /both named/.test(x)));
+});
+test('rejects a syntactically valid but impossible CIDR', () => {
+  const e = validateRouterConfig({ lan: { address: '999.999.999.999/99' }, wan: [{ interface: 'e1' }] });
+  assert.ok(e.some(x => /not valid CIDR/.test(x)));
+});
+test('rejects a malformed pool and lease time', () => {
+  const e = validateRouterConfig({
+    lan: { address: '192.168.80.1/24', dhcpServer: { pool: 'not-a-range', leaseTime: 'forever' } },
+    wan: [{ name: 'a', interface: 'e1' }]
+  });
+  assert.ok(e.some(x => /pool .* must look like/.test(x)));
+  assert.ok(e.some(x => /leaseTime .* must look like/.test(x)));
 });
 test('rejects static and pppoe uplinks missing required fields', () => {
   const e = validateRouterConfig({


### PR DESCRIPTION
Fourteen findings from a second independent adversarial review (Codex) of the router role. **2 Critical, 6 High, 5 Medium, 1 Low.**

This is a security fix. v6.1.0 and v6.1.1 are both affected and both published to GHCR.

## Critical

### Command injection via configuration values

Every value from a YAML config was interpolated raw into RouterOS CLI command strings. `escapeMikroTik()` existed in `lib/utils.js` but was **not imported or used anywhere** in `lib/router.js`.

Two consequences. The mundane one, which is the likelier to bite you: a legitimate value containing a quote or a dollar sign — an ISP PPPoE password is the obvious case — produces a malformed command that fails or configures the wrong object.

```
# with password: pa"ss;word
/interface pppoe-client add ... password="pa"ss;word" add-default-route=no
```

The serious one: a crafted value closes the quoted string and appends further commands, which RouterOS runs with the SSH account's full privileges.

```
# with a wan name of: x" ; /user add name=evil password=p group=full; #
/ip dhcp-client add interface=ether1 comment="wan:x" ; /user add name=evil password=p group=full; #"
```

New `lib/routeros-args.js` is the single place arguments are encoded, and it draws the distinction that actually matters: quoted arguments are escaped with `q()`, while unquoted ones — interface names, addresses, durations, distances — **cannot be rescued by escaping** and are instead checked against strict patterns that throw. A bad value stops the apply rather than being silently rewritten. `lib/wifi-config.js`, shared with the AP roles, is covered too.

### Cleanup ran even when the new LAN address was never added

`addLanAddress()` returned `false` on failure; `configureRouter()` discarded it and ran `removeStaleLanAddresses()` anyway. Cleanup now runs only after the desired address is read back from the device.

## High

- **The firewall drop rule trusted an unverified accept rule.** Replacement rules use `execWithWarning()`, which logs and continues — so a failed `router:input-lan` did not stop the WAN drop rule from landing. The LAN-list check proved only that `bridge` was a member, not that the accept rule existed. The drop is now added only after the accept rule is confirmed present; otherwise it is skipped and the router is left open on its uplinks rather than unreachable.
- **Cleanup deleted addresses it did not own.** Stale-address removal took every non-desired static address on the bridge — including a hand-added recovery address — contradicting the comment-ownership model used everywhere else. Static WAN setup likewise took every non-dynamic address on its interface. Both are now scoped to this tool's own comments.
- **Applying during an outage made the outage worse.** All routes were removed up front and rebuilt only for gateways resolvable in a single read, so an uplink that was down at apply time lost its routes with nothing to restore. Gateways are now resolved *before* anything is removed, each uplink is reconciled independently, and an apply where nothing resolves leaves the table untouched.
- **An SSID could not move from tagged to untagged.** RouterOS `set` leaves unspecified properties alone, so omitting the VLAN clause left the old `datapath.vlan-id` in place. Now unset explicitly — with a fallback, because that syntax is not confirmed across every RouterOS build and this path configures every SSID for every role.
- **Validation only looked at what the user typed.** `normalizeWans()` fills in distances and probes, so an implicit default colliding with an explicit value passed, as did the common `lan.dns.servers: [8.8.8.8]` alongside a default probe of `8.8.8.8`. Validation now runs against the normalized list.

## Medium / Low

Duplicate uplink names are rejected (names key route comments, PPPoE client names, APN profile names and the backup map, so a collision made one uplink overwrite another's objects); `CIDR_RE` checked shape only, so `999.999.999.999/99` passed; `lan.ports`, `lan.dns.servers`, `dhcpServer.pool` and `dhcpServer.leaseTime` are now type-checked; apply reported "Complete" regardless of outcome, and `verifyRouterState()` now throws listing unmet postconditions; PPPoE passwords were dropped from backups, so applying a backup reset the uplink with an empty password.

## Tests

38 assertions, up from 29. The new ones attempt quote, dollar-sign, semicolon and `[find]` injection against both quoted and unquoted argument positions, and cover each validation gap above.

## Verification status

**Not exercised on hardware** — code-verified and unit-tested only, same as v6.1.1. The test device is running production config and is unreachable to me.

The two changes I would most want confirmed on a device: the `!datapath.vlan-id` unset syntax (deliberately made fail-safe, but a fallback path is still a path), and the new postcondition checks, which now *throw* where the tool previously reported success — so a device state I have not anticipated could turn a working apply into a failed one.

## Recommendation

Cut v6.1.2 promptly once merged. The published `:latest` and `:6.1.1` images carry the injection flaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhqvP2dpczufSBaNkz67pa