### PR TITLE
Notify when the active WAN changes (v6.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,131 @@
 # Changelog
 
+## [6.2.0] - 2026-08-25 - WAN Failover Notifications
+
+Adds an optional `notify` block to `role: router`. When the active uplink
+changes — wired to LTE, and back — the device POSTs a short message to an
+endpoint you choose.
+
+Failover is silent by default, which is the actual problem with it: the router
+moves to LTE, everything keeps working, and you find out weeks later from the
+data bill.
+
+### Configuration
+
+```yaml
+role: router
+
+notify:
+  url: https://ntfy.sh/your-topic-here   # required; any http(s) POST target
+  title: office router failover          # optional; sent as an X-Title header
+  interval: 30s                          # optional; default 30s
+  checkCertificate: false                # optional; default false
+```
+
+The message body names the uplinks from your own `wan` block, prefixed with the
+router's identity so one topic can carry several routers:
+
+```
+nick-office-router WAN: primary -> backup
+```
+
+Leaving the block out installs nothing. Removing it later removes the notifier
+from the device on the next apply, so deleting the config really does turn it
+off. The settings round-trip through `backup-config.js` like everything else.
+
+### What it installs
+
+A `wan-notify` script and a scheduler of the same name, both commented
+`router:wan-notify` — the same comment-ownership convention the rest of the
+router role uses. Re-applying replaces them and leaves hand-added objects
+alone. A `wan-notify` object that does *not* carry that comment is reported and
+left untouched rather than overwritten.
+
+The active uplink is read from the routes the role already writes
+(`/ip route find comment="wan:<name> default" active=yes`), so there is no
+second source of truth about which uplink is preferred.
+
+### State lives in the script's comment, not in a `:global`
+
+This is the one detail that took hardware to get right.
+
+**A `:global` set by a script the scheduler runs is discarded before the next
+tick.** After clearing the variable and letting the scheduler run repeatedly, it
+was absent from `/system/script/environment` entirely. Every tick would see
+"unknown" and notify again.
+
+The trap is that the same script run by hand with `/system script run` *does*
+persist its globals, so the bug passes every interactive test.
+
+The state is therefore written into the script object's own comment,
+`router:wan-notify state=<uplink>`. That is configuration, so unlike a global it
+also survives a reboot, and it is written only when the uplink actually changes,
+so there is no flash wear.
+
+### A failed send is retried, not lost
+
+The stored state advances only *after* the POST succeeds. A failover that took
+the internet with it therefore notifies as soon as the backup link is carrying
+traffic, instead of being swallowed. Both outcomes are logged:
+
+```
+/log print where message~"wan-notify"
+```
+
+A total outage resolves to the state `none`, which is a transition of its own
+rather than a stale "still on primary".
+
+### RouterOS device-mode blocks this on a factory device
+
+The Chateau LTE6 ships in `mode: home`, where **both `fetch` and `scheduler` are
+disabled**. `/system/scheduler/add` fails outright with "failure: not allowed by
+device-mode", and `/tool/fetch` fails the same way at runtime.
+
+Applying now checks `/system/device-mode/print` first and stops at this feature
+with the fix spelled out, rather than surfacing RouterOS's error:
+
+```
+/system/device-mode/update scheduler=yes fetch=yes
+```
+
+followed by a physical power cycle or reset-button press within five minutes.
+RouterOS wants proof of physical access and no tool can supply it. Everything
+else in the config is applied normally; only the notifier is skipped.
+
+### Smaller decisions
+
+- **`check-certificate=no` by default.** A factory device has zero CA
+  certificates (`/certificate print count-only` returns 0) and the test device
+  had ~292 KiB of flash free, far too little for a bundle. HTTPS works out of
+  the box; `checkCertificate: true` turns verification on once you have imported
+  a certificate, and warns that an empty store will fail every send.
+- **`output=none` on the fetch**, so nothing writes a result file to that flash.
+- **A comma in `title` is rejected.** RouterOS separates multiple
+  `http-header-field` values with commas, so a comma would split the header.
+- **An interval under 10 s warns.** A POST to an unreachable endpoint took about
+  ten seconds to give up, and the check blocks for that whole time.
+- **A plain `http://` endpoint warns.** For ntfy and most webhook services the
+  URL *is* the credential.
+
+### New in lib/routeros-args.js
+
+`scriptSource()` encodes a multi-line RouterOS script as a `source=` argument. A
+command reaches the device as one line, so real newlines would end the string
+mid-command; they are rewritten to RouterOS's `\n` escape *after* the body is
+escaped, which also leaves `$cur` intact (`\$` on the wire, `$` once stored).
+Two new patterns, `HTTP_URL` and `NOTIFY_TITLE`, are shared by the validator and
+the applier so a config applied as a library call is checked the same way.
+
+### Verified
+
+On the Chateau LTE6 (`D53G-5HacD2HnD&EG06-A`, RouterOS 7.18.2), against a local
+HTTP sink: the generated script round-tripped through escaping unchanged, read
+the live routes and resolved the active uplink correctly, delivered the POST
+with its `X-Title` header, advanced its comment, sent nothing at all on a second
+run, and — pointed at a dead endpoint — left the state untouched and logged that
+it would retry.
+
+
 ## [6.1.2] - 2026-08-23 - Command Injection and Lockout Fixes
 
 Fixes fourteen findings from a second, independent adversarial review (Codex)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,7 @@ const BAND_TO_INTERFACE = {
     ports: [ether2, ether3, ether4, ether5]
     dhcpServer: {pool: 192.168.80.100-192.168.80.200, leaseTime: 12h}
     dns: {servers: [1.1.1.1, 8.8.8.8], allowRemoteRequests: true}
+  notify: {url: https://ntfy.sh/topic, title: office router failover, interval: 30s}  # optional
   wan:
     - {name: primary, interface: ether1, type: dhcp, distance: 1, probe: 8.8.8.8}
     - {name: backup, interface: lte1, type: lte, apn: fast.t-mobile.com, distance: 2, probe: 1.1.1.1}
@@ -317,11 +318,42 @@ const BAND_TO_INTERFACE = {
 - Every uplink gets `use-peer-dns=no` and the router uses `lan.dns.servers`. Keeping ISP resolvers means that after failover, routing works but every lookup times out - which reads as a failed failover and is very hard to diagnose.
 - Each uplink needs its OWN probe address. Two uplinks sharing one probe fight over the same probe route. Validation rejects this.
 
+**Router Role: WAN Failover Notification (Added v6.2.0)**
+- Optional `notify` block on a `role: router` config. Installs a `wan-notify` script plus a scheduler of the same name, both commented `router:wan-notify`. Absent block = both removed, so deleting the block turns it off.
+- Shape: `notify: {url, title?, interval?, checkCertificate?}`. `url` is any http(s) POST target; `title` becomes an `X-Title:` header (ntfy renders it); `interval` defaults to `30s`; `checkCertificate` defaults to FALSE.
+- Message body: `<identity> WAN: <prev uplink> -> <cur uplink>`, using the names from the `wan` block.
+- Implemented in `lib/router.js` (`wanNotifyScript`, `configureWanNotify`, `backupWanNotify`, `parseDeviceMode`).
+
+**`:global` DOES NOT PERSIST BETWEEN SCHEDULER RUNS (the trap this feature is built around)**
+- A `:global` set by a script the SCHEDULER runs is discarded before the next tick. Verified: after clearing it and letting the scheduler tick repeatedly, the variable was absent from `/system/script/environment` entirely.
+- The same script run by hand with `/system script run` DOES persist it. So the bug looks like it works in every interactive test. Do not "fix" the comment-based state back into a global.
+- State is stored in the script object's own `comment`: `router:wan-notify state=<uplink>`. It is config, so it survives a reboot (a global does not), and it is written only on a real change, so there is no flash wear.
+- Read it with `[/system script get $id comment]`. Confirmed the write is attributed to `scheduler:wan-notify`, so a scheduler-run script really can persist its own state this way.
+
+**Device-mode Can Block This Entirely**
+- On a Chateau LTE6 in `mode: home`, BOTH `fetch` and `scheduler` are disabled. `/system/scheduler/add` fails with "failure: not allowed by device-mode"; `/tool/fetch` fails the same way at runtime.
+- Unlock: `/system/device-mode/update scheduler=yes fetch=yes`, then a PHYSICAL power cycle or reset-button press within 5 minutes. No tool can do that step.
+- `configureWanNotify()` reads `/system/device-mode/print` FIRST and fails with that instruction rather than surfacing the low-level error. Everything else in the apply still lands; the problem is reported through `configureRouter()`'s postcondition list.
+- `/tool/netwatch` is NOT device-mode gated, if a future feature needs a scheduler-free trigger.
+- Parse the flags with `parseDeviceMode()`. A device that reports no device-mode at all returns null, which means "cannot tell", not "blocked".
+
+**Notifier Implementation Details (all verified on hardware)**
+- `check-certificate=no` is the default because a factory device has ZERO certificates (`/certificate/print count-only` = 0) and this one had ~292KiB of flash free, too little for a CA bundle.
+- `output=none` on `/tool fetch`, for the same flash reason.
+- Advance the stored state ONLY inside the `:do {...}` block, after the fetch. A failed send then retries on the next tick instead of being lost - which is exactly the failover that took the internet with it. Log both outcomes with `:log`.
+- Detect the active uplink from the routes the role already writes: `[:len [/ip route find comment="wan:<name> default" active=yes]] > 0`. Emit one `:if` per uplink, WORST distance first, so the most preferred active uplink wins the last assignment. `cur` starts at `"none"` so a total outage is a state of its own.
+- `/system/script/print detail` output CONTAINS THE SOURCE, so grepping the record for `state=` matches the code that writes the comment. Read the comment field: `:foreach s in=[/system script find comment~"^router:wan-notify"] do={:put [/system script get $s comment]}`.
+- A script body cannot be sent with real newlines (they end the command). `scriptSource()` in `lib/routeros-args.js` escapes with `escapeMikroTik()` FIRST and rewrites newlines to `\n` second. `$` becomes `\$` on the wire and lands back as `$` in the stored source, so script variables survive.
+- Re-apply preserves the stored state when it still names a configured uplink, so applying does not itself fire a notification. A fresh install deliberately sends `unknown -> <uplink>` on the first tick, which proves the whole path works.
+- A `wan-notify` script or scheduler that is NOT commented `router:wan-notify` belongs to someone else. Report it and stop; do not add over it.
+- A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
+- A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
+
 **Router Role: Interface Lists and Comment Conventions**
 - Maintains the `WAN` and `LAN` interface lists that RouterOS defconf already uses. One NAT rule (`out-interface-list=WAN`) and one firewall rule cover every uplink.
 - The `WAN` list member comment is the AUTHORITATIVE record: `wan:<name> type=... distance=... probe=... [apn=...]`.
 - Why: routes only exist while a link is up. Reading settings back from routes alone drops an unplugged uplink from the backup. The list member is always present.
-- Other comments: routes `wan:<name> probe` / `wan:<name> default`, NAT `router:masquerade`, filter `router:<purpose>`, DHCP/pool/address `router:lan`.
+- Other comments: routes `wan:<name> probe` / `wan:<name> default`, NAT `router:masquerade`, filter `router:<purpose>`, DHCP/pool/address `router:lan`, notifier `router:wan-notify [state=<uplink>]`.
 - Backup detects the role via the `router:masquerade` NAT rule, not via routes, for the same reason.
 - RouterOS `print detail` renders comments as `;;; <comment>` lines, NOT as `comment="..."`. Parse with `recordComment()` in `lib/router.js`. Getting this wrong silently returns nothing.
 - `/ip dns print` wraps a multi-server list onto unlabelled continuation lines. Collect lines until the next `label:`.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The script is **idempotent** and safe to run multiple times.
 - **Automatic failover** - Traffic moves to the next uplink when one dies
 - **Path-aware health checks** - Probes a real internet address, not just the next hop
 - **Full gateway stack** - NAT, DHCP server, DNS cache and a firewall
+- **Failover notifications** - Optional push message when the active uplink changes (`notify`)
 - See `router.example.yaml` for a complete configuration
 
 ### Enterprise Features
@@ -286,6 +287,57 @@ like the failover had failed.
 
 **The tool owns the default routes.** Every uplink is created with
 `add-default-route=no`, so nothing competes with the failover routes.
+
+### Getting told when it fails over
+
+Failover is silent by default: the router switches to LTE and everything keeps
+working, which is exactly the problem. You find out weeks later, from the data
+bill. Add a `notify` block and the device posts a message when the active
+uplink changes.
+
+```yaml
+notify:
+  url: https://ntfy.sh/your-topic-here   # any endpoint that accepts a POST
+  title: office router failover          # optional, sent as an X-Title header
+  interval: 30s                          # optional, how often it checks
+```
+
+The message names the uplinks from your own `wan` block, prefixed with the
+router's identity so one topic can carry several routers:
+
+```
+nick-office-router WAN: primary -> backup
+```
+
+This installs a `wan-notify` script and a scheduler of the same name, both
+commented `router:wan-notify`. Re-applying replaces them and nothing else;
+removing the block removes them.
+
+**Device-mode blocks this on a factory device.** RouterOS ships the Chateau
+LTE6 in `mode: home`, where both `fetch` and `scheduler` are disabled — the
+apply says so and skips this feature rather than failing with RouterOS's
+"not allowed by device-mode". To unlock, on the device:
+
+```
+/system/device-mode/update scheduler=yes fetch=yes
+```
+
+then power-cycle it or press the reset button **within five minutes**.
+RouterOS wants proof of physical access, so no tool can do that step for you.
+
+Three smaller things worth knowing:
+
+- **Certificate checking is off by default.** A factory device has no CA
+  certificates at all and often lacks the flash to import a bundle, so
+  `check-certificate=no` is what makes an HTTPS endpoint work out of the box.
+  Set `checkCertificate: true` once you have imported one.
+- **A failed send is retried, not lost.** The device only records the new
+  uplink after the POST succeeds, so a failover that took the internet with it
+  notifies as soon as the backup link is carrying traffic. Both outcomes are
+  logged: `/log print where message~"wan-notify"`.
+- **Detection lags by up to one `interval`** on top of the failover times
+  above. Keep the interval comfortably above 10 s, roughly how long
+  `/tool fetch` takes to give up on an unreachable endpoint.
 
 ### A limit worth knowing
 

--- a/apply-config.js
+++ b/apply-config.js
@@ -139,6 +139,9 @@ async function main() {
       const dist = wan.distance !== undefined ? wan.distance : '?';
       console.log(`  - ${wan.name || wan.interface}: ${wan.interface} (${wan.type || 'dhcp'}), distance ${dist}`);
     });
+    if (config.notify?.url) {
+      console.log(`WAN change notifications: POST to ${config.notify.url} every ${config.notify.interval || '30s'}`);
+    }
     if (config.ssids?.length) {
       console.log(`SSIDs to configure: ${config.ssids.length}`);
     }

--- a/backup-multiple-devices.js
+++ b/backup-multiple-devices.js
@@ -127,6 +127,9 @@ async function main() {
         console.log(`  Role: router`);
         console.log(`  LAN: ${config.lan?.address || 'unset'}`);
         console.log(`  Uplinks: ${(config.wan || []).map(w => `${w.name}(${w.interface})`).join(', ') || 'none'}`);
+        if (config.notify?.url) {
+          console.log(`  WAN change notifications: ${config.notify.url}`);
+        }
       } else {
         const mgmtDisplay = (config.managementInterfaces || []).map(iface => {
           if (typeof iface === 'string') {

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -662,6 +662,9 @@ async function backupMikroTikConfig(credentials = {}) {
         config.role = 'router';
         config.lan = router.lan;
         config.wan = router.wan;
+        // Only present when the WAN failover notifier is installed. Assigning
+        // it unconditionally would dump `notify: null` into the YAML.
+        if (router.notify) config.notify = router.notify;
         delete config.managementInterfaces;
         delete config.disabledInterfaces;
       }

--- a/lib/router.js
+++ b/lib/router.js
@@ -11,6 +11,7 @@
  *   - NAT rules         "router:masquerade"
  *   - filter rules      "router:<purpose>"
  *   - pool / server     "router:lan"
+ *   - notifier          "router:wan-notify [state=<uplink>]"
  * Re-applying finds objects by those comments and replaces them, so a second
  * run is a no-op and hand-added objects are left alone.
  */
@@ -27,8 +28,8 @@ const {
   execIdempotent,
   execWithWarning
 } = require('./infrastructure');
-const { getWifiPath } = require('./utils');
-const { q, must, ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List, IDENTIFIER } = require('./routeros-args');
+const { getWifiPath, escapeMikroTik } = require('./utils');
+const { q, must, scriptSource, ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List, IDENTIFIER, HTTP_URL, NOTIFY_TITLE } = require('./routeros-args');
 const { CHANNEL_FREQ_24GHZ, CHANNEL_FREQ_5GHZ } = require('./constants');
 const { detectRadioLayout, detectBandToken, configureWifiInterface } = require('./wifi-config');
 
@@ -235,6 +236,396 @@ function parseWanMemberComment(comment) {
     }
   }
   return link;
+}
+
+/* ------------------------------------------------------------------ */
+/* WAN failover notification                                           */
+/* ------------------------------------------------------------------ */
+
+const NOTIFY_SCRIPT = 'wan-notify';
+const NOTIFY_TAG = 'router:wan-notify';
+const NOTIFY_DEFAULT_INTERVAL = '30s';
+
+/**
+ * Short name for this router, used as the first word of the message so one
+ * notification topic can carry several routers.
+ * @param {Object} config - Device configuration
+ * @returns {string}
+ */
+function notifyLabel(config = {}) {
+  if (config.identity) return config.identity;
+  const host = config.host || '';
+  if (host && !/^\d+\.\d+\.\d+\.\d+$/.test(host)) return host.split('.')[0];
+  return 'router';
+}
+
+/**
+ * Read the feature flags out of `/system/device-mode/print`.
+ *
+ * On a device shipped in `mode: home` - the Chateau LTE6 is one - both
+ * `scheduler` and `fetch` are off, and this feature needs both. Unlocking them
+ * takes physical access, so the only useful thing the tool can do is say so
+ * precisely instead of letting `/system/scheduler/add` fail with
+ * "not allowed by device-mode".
+ *
+ * @param {string} output - Raw command output
+ * @returns {{mode: string|null, scheduler: boolean, fetch: boolean}|null} -
+ *          null when the device does not report device-mode at all
+ */
+function parseDeviceMode(output) {
+  if (!output) return null;
+  const flag = (name) => {
+    const match = output.match(new RegExp(`^\\s*${name}:\\s*(\\S+)`, 'm'));
+    return match ? match[1] : null;
+  };
+  const scheduler = flag('scheduler');
+  const fetch = flag('fetch');
+  if (scheduler === null && fetch === null) return null;
+  return { mode: flag('mode'), scheduler: scheduler !== 'no', fetch: fetch !== 'no' };
+}
+
+/**
+ * Build the RouterOS script that detects a WAN change and posts a message.
+ *
+ * The state - which uplink was active last time - lives in this script's own
+ * `comment`, which is the one detail that took hardware to get right. A
+ * `:global` looks like it works, because a script run by hand with
+ * `/system script run` does keep its globals. A script run by the SCHEDULER
+ * does not: the variable is gone from `/system/script/environment` by the next
+ * tick, so every tick sees "unknown" and notifies again. A comment is config,
+ * so it also survives a reboot, and it is written only on a real change.
+ *
+ * The state is advanced only after the POST succeeds. A failover that took the
+ * internet with it therefore retries on the next tick instead of being lost.
+ *
+ * @param {Array<Object>} wans - Normalised WAN links, best first
+ * @param {Object} options - {url, title, label, checkCertificate}
+ * @returns {string} - Script body with real newlines
+ */
+function wanNotifyScript(wans, { url, title, label, checkCertificate = false } = {}) {
+  // These values are string literals INSIDE the generated script. scriptSource()
+  // escapes the script as a whole when it is sent, and the two compose: an inner
+  // \" becomes \\\" on the wire and lands back as \" in the stored source.
+  const lit = value => escapeMikroTik(String(value));
+
+  const lines = [
+    `# ${NOTIFY_TAG} - written by mikrotik-as-wap-configurator, edits are overwritten`,
+    `:local url "${lit(url)}"`,
+    `:local label "${lit(label)}"`
+  ];
+  if (title) lines.push(`:local title "${lit(title)}"`);
+  lines.push(
+    `:local id [/system script find name="${NOTIFY_SCRIPT}"]`,
+    '',
+    '# Which uplink is carrying traffic right now. Written worst-first so the',
+    '# most preferred active uplink wins, and "none" survives a total outage.',
+    ':local cur "none"'
+  );
+  for (const wan of [...wans].reverse()) {
+    lines.push(
+      `:if ([:len [/ip route find comment="wan:${lit(wan.name)} default" active=yes]] > 0) ` +
+      `do={ :set cur "${lit(wan.name)}" }`
+    );
+  }
+
+  const fetchArgs = [
+    'url=$url',
+    'http-method=post',
+    'http-data=$msg',
+    title ? 'http-header-field=$hdr' : null,
+    // A default device has no CA certificates and rarely has the flash to
+    // import a bundle, so verification is off unless it is asked for.
+    `check-certificate=${checkCertificate ? 'yes' : 'no'}`,
+    // Writing a result file onto a device with a few hundred KiB free is not
+    // worth it, and nothing reads the body.
+    'output=none'
+  ].filter(Boolean).join(' ');
+
+  lines.push(
+    '',
+    `:local have [/system script get $id comment]`,
+    `:local want ("${lit(NOTIFY_TAG)} state=" . $cur)`,
+    '',
+    ':if ($have != $want) do={',
+    '  :local prev "unknown"',
+    '  :local p [:find $have "state=" -1]',
+    '  :if ([:typeof $p] = "num") do={ :set prev [:pick $have ($p + 6) [:len $have]] }',
+    '  :local msg ($label . " WAN: " . $prev . " -> " . $cur)'
+  );
+  if (title) lines.push('  :local hdr ("X-Title: " . $title)');
+  lines.push(
+    '  :do {',
+    `    /tool fetch ${fetchArgs}`,
+    '    /system script set $id comment=$want',
+    `    :log info ("${NOTIFY_SCRIPT}: sent " . $msg)`,
+    '  } on-error={',
+    `    :log warning ("${NOTIFY_SCRIPT}: send failed for " . $msg . ", will retry")`,
+    '  }',
+    '}'
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Recover the notify settings from a script this tool wrote.
+ *
+ * The generated source is the record, so the header lines it emits are read
+ * back rather than guessed at. Note that `/system script print detail` includes
+ * the SOURCE, so anything that greps that output for a marker also matches the
+ * code that writes the marker - read the fields, not the blob.
+ *
+ * @param {string} source - Script source as the device prints it
+ * @returns {{url: string|null, title: string|null, checkCertificate: boolean}}
+ */
+function parseWanNotifyScript(source) {
+  const literal = (name) => {
+    const match = (source || '').match(new RegExp(`:local ${name} "((?:[^"\\\\]|\\\\.)*)"`));
+    return match ? match[1].replace(/\\(.)/g, '$1') : null;
+  };
+  return {
+    url: literal('url'),
+    title: literal('title'),
+    checkCertificate: /check-certificate=yes/.test(source || '')
+  };
+}
+
+/**
+ * Remove the notifier objects this tool owns.
+ * Deleting the `notify` block from a config has to actually turn notifications
+ * off, so this runs even when the block is absent.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {boolean} announce - Log when something was removed
+ */
+async function removeWanNotify(mt, announce = false) {
+  let existed = false;
+  try {
+    const found = await mt.exec(`/system scheduler print terse where comment=${q(NOTIFY_TAG)}`);
+    existed = Boolean(found && found.trim());
+  } catch (e) { /* treat as absent */ }
+
+  for (const cmd of [
+    `/system scheduler remove [find comment=${q(NOTIFY_TAG)}]`,
+    `/system script remove [find comment~${q(`^${NOTIFY_TAG}`)}]`
+  ]) {
+    try { await mt.exec(cmd); } catch (e) { /* none present */ }
+  }
+
+  if (existed && announce) {
+    console.log('✓ Removed the WAN failover notifier (no notify block in this config)');
+  }
+}
+
+/**
+ * Read back the state this tool stored in the script's comment.
+ * `print terse` on a script includes its SOURCE, and the source contains the
+ * string it writes into the comment - so grepping the whole record for
+ * `state=` matches the code rather than the state. Ask for the field.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @returns {Promise<string|null>} - The uplink name last notified about
+ */
+async function readWanNotifyState(mt) {
+  try {
+    const out = await mt.exec(
+      `:foreach s in=[/system script find comment~${q(`^${NOTIFY_TAG}`)}] ` +
+      'do={:put [/system script get $s comment]}'
+    );
+    const match = out && out.match(/state=(\S+)/);
+    return match ? match[1] : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Install (or remove) the WAN failover notifier.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} config - Device configuration
+ * @param {Array<Object>} wans - Normalised WAN links
+ * @returns {Promise<string[]>} - Problems found, empty when healthy
+ */
+async function configureWanNotify(mt, config, wans) {
+  const notify = config.notify;
+  const problems = [];
+
+  if (!notify || !notify.url) {
+    await removeWanNotify(mt, true);
+    return problems;
+  }
+
+  console.log('\n=== Configuring WAN Failover Notification ===');
+
+  // configureRouter() is usable as a library function, so the entry points'
+  // validation has not necessarily run. Check every value BEFORE touching the
+  // device: a checker throwing halfway through would leave a script behind
+  // with no scheduler to run it.
+  const interval = notify.interval || NOTIFY_DEFAULT_INTERVAL;
+  try {
+    // The url and title are quoted string literals inside the generated
+    // script rather than bare command arguments, so the shape check is about
+    // keeping that script parseable - and readable back by backup - rather
+    // than about escaping, which q()/scriptSource() already handle.
+    if (!HTTP_URL.test(String(notify.url))) {
+      throw new Error(`notify.url ${JSON.stringify(String(notify.url))} must be an http:// or https:// URL with no spaces or quotes`);
+    }
+    if (notify.title !== undefined && !NOTIFY_TITLE.test(String(notify.title))) {
+      throw new Error(`notify.title ${JSON.stringify(String(notify.title))} must be 1-64 characters with no comma, quote or newline`);
+    }
+    duration(interval, 'notify.interval');
+  } catch (e) {
+    console.log(`✗ ${e.message}`);
+    problems.push(`the WAN failover notifier was not installed: ${e.message}`);
+    return problems;
+  }
+
+  // Both `fetch` and `scheduler` are disabled by default in device-mode `home`,
+  // and unlocking them needs physical access. Check first: the alternative is
+  // "failure: not allowed by device-mode" from /system/scheduler/add, which
+  // says nothing about what to do next.
+  let deviceMode = null;
+  try {
+    deviceMode = parseDeviceMode(await mt.exec('/system/device-mode/print'));
+  } catch (e) {
+    console.log(`⚠️  Could not read device-mode (${e.message}), continuing anyway`);
+  }
+
+  if (deviceMode && (!deviceMode.scheduler || !deviceMode.fetch)) {
+    const off = [
+      deviceMode.scheduler ? null : 'scheduler',
+      deviceMode.fetch ? null : 'fetch'
+    ].filter(Boolean);
+
+    console.log(`✗ RouterOS device-mode blocks ${off.join(' and ')} on this device` +
+      `${deviceMode.mode ? ` (mode: ${deviceMode.mode})` : ''}.`);
+    console.log('    The notifier needs both, so it was not installed. On the device run:');
+    console.log('');
+    console.log('      /system/device-mode/update scheduler=yes fetch=yes');
+    console.log('');
+    console.log('    RouterOS then waits for proof of physical access: power-cycle the');
+    console.log('    device, or press its reset button, WITHIN 5 MINUTES or the change is');
+    console.log('    discarded. This tool cannot do that step for you. Apply again after.');
+    console.log('    Everything else in this config was applied normally.');
+
+    problems.push(
+      `device-mode blocks ${off.join(' and ')}, so the WAN failover notifier could not be installed ` +
+      '(run /system/device-mode/update scheduler=yes fetch=yes, then power-cycle within 5 minutes)'
+    );
+    return problems;
+  }
+
+  const label = notifyLabel(config);
+  const source = wanNotifyScript(wans, {
+    url: notify.url,
+    title: notify.title,
+    label,
+    checkCertificate: notify.checkCertificate === true
+  });
+
+  // Carry the last-notified uplink across a re-apply, so applying does not
+  // itself produce a notification. A state naming an uplink that no longer
+  // exists is dropped - that change IS worth announcing.
+  const previousState = await readWanNotifyState(mt);
+  const keepState = previousState && wans.some(w => w.name === previousState) ? previousState : null;
+
+  await removeWanNotify(mt);
+
+  // Only objects carrying this tool's comment were removed above. A leftover
+  // of the same name without that comment belongs to someone else; adding over
+  // it would fail with a bare "already have such name".
+  for (const [path, what] of [['/system script', 'script'], ['/system scheduler', 'scheduler']]) {
+    try {
+      const clash = await mt.exec(`${path} print terse where name=${q(NOTIFY_SCRIPT)}`);
+      if (clash && clash.trim()) {
+        const message =
+          `a ${what} named "${NOTIFY_SCRIPT}" already exists and is not commented "${NOTIFY_TAG}", ` +
+          'so the WAN failover notifier was not installed - rename or remove it, or add that comment to adopt it';
+        console.log(`✗ ${message}`);
+        problems.push(message);
+        return problems;
+      }
+    } catch (e) { /* nothing there */ }
+  }
+
+  await execWithWarning(
+    mt,
+    `/system script add name=${NOTIFY_SCRIPT} policy=read,write,test ` +
+      `source=${scriptSource(source)} ` +
+      `comment=${q(keepState ? `${NOTIFY_TAG} state=${keepState}` : NOTIFY_TAG)}`,
+    `Script ${NOTIFY_SCRIPT}${keepState ? ` (state kept: ${keepState})` : ''}`,
+    `Could not add the ${NOTIFY_SCRIPT} script`
+  );
+
+  await execWithWarning(
+    mt,
+    `/system scheduler add name=${NOTIFY_SCRIPT} interval=${duration(interval, 'notify.interval')} ` +
+      `on-event=${q(`/system/script/run ${NOTIFY_SCRIPT}`)} policy=read,write,test ` +
+      `comment=${q(NOTIFY_TAG)}`,
+    `Scheduler ${NOTIFY_SCRIPT} every ${interval}`,
+    `Could not add the ${NOTIFY_SCRIPT} scheduler`
+  );
+
+  // execWithWarning() only logs, so read both back before claiming this works.
+  for (const [path, what] of [['/system script', 'script'], ['/system scheduler', 'scheduler']]) {
+    try {
+      const found = await mt.exec(`${path} print terse where name=${q(NOTIFY_SCRIPT)}`);
+      if (!found || !found.trim()) problems.push(`the ${NOTIFY_SCRIPT} ${what} is missing after apply`);
+    } catch (e) {
+      problems.push(`could not verify the ${NOTIFY_SCRIPT} ${what}: ${e.message}`);
+    }
+  }
+
+  if (problems.length === 0) {
+    console.log(`✓ POSTs to ${notify.url} when the active uplink changes`);
+    if (!keepState) {
+      console.log(`    The first tick sends "${label} WAN: unknown -> <uplink>", which confirms`);
+      console.log('    the whole path works. Nothing arrives? Check /log print where message~"wan-notify".');
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Read the notify block back off a device.
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @returns {Promise<Object|null>}
+ */
+async function backupWanNotify(mt) {
+  let scheduler;
+  try {
+    scheduler = await mt.exec(`/system scheduler print detail without-paging where comment=${q(NOTIFY_TAG)}`);
+  } catch (e) {
+    return null;
+  }
+  if (!scheduler || !scheduler.trim()) return null;
+
+  let source = '';
+  try {
+    source = await mt.exec(`/system script print detail without-paging where comment~${q(`^${NOTIFY_TAG}`)}`);
+  } catch (e) { /* script gone, scheduler orphaned */ }
+
+  const { url, title, checkCertificate } = parseWanNotifyScript(source);
+  if (!url) {
+    // Either the script is gone, or it was written by hand rather than by this
+    // tool and has no `:local url` line to read. Applying a config with a
+    // notify block would replace it; saying nothing here would silently drop
+    // a working notifier from the backup.
+    console.log(`⚠️  A ${NOTIFY_SCRIPT} scheduler is present, but no script this tool wrote was found alongside it`);
+    console.log('    (a hand-written script has no readable url), so notify is left out of the backup.');
+    return null;
+  }
+
+  const notify = { url };
+  if (title) notify.title = title;
+  const interval = scheduler.match(/interval=(\S+)/);
+  notify.interval = interval ? interval[1] : NOTIFY_DEFAULT_INTERVAL;
+  if (checkCertificate) notify.checkCertificate = true;
+
+  console.log(`✓ WAN failover notification: ${url} every ${notify.interval}`);
+  return notify;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1269,7 +1660,9 @@ async function backupRouterConfig(mt) {
     }
   } catch (e) { /* absent */ }
 
-  return { lan, wan };
+  const notify = await backupWanNotify(mt);
+
+  return notify ? { lan, wan, notify } : { lan, wan };
 }
 
 /**
@@ -1530,6 +1923,10 @@ async function configureRouter(config = {}) {
     await configureRouterWifi(mt, config);
     await configureSyslog(mt, config);
 
+    // Runs after the failover routes exist, because the notifier reads their
+    // comments to decide which uplink is active.
+    const notifyProblems = await configureWanNotify(mt, config, wans);
+
     let pending = false;
     if (lan.address && lanAddressReady) {
       pending = await removeStaleLanAddresses(mt, lan, config.host);
@@ -1538,7 +1935,7 @@ async function configureRouter(config = {}) {
       console.log('\n⚠️  Skipping stale-address cleanup because the LAN address was not added.');
     }
 
-    const problems = await verifyRouterState(mt, lan);
+    const problems = [...(await verifyRouterState(mt, lan)), ...notifyProblems];
     if (problems.length > 0) {
       console.log('\n========================================');
       console.log('✗ Router Configuration INCOMPLETE');
@@ -1585,5 +1982,11 @@ module.exports = {
   resolveHostAddress,
   verifyRouterState,
   wanMemberComment,
-  parseWanMemberComment
+  parseWanMemberComment,
+  configureWanNotify,
+  backupWanNotify,
+  wanNotifyScript,
+  parseWanNotifyScript,
+  parseDeviceMode,
+  notifyLabel
 };

--- a/lib/routeros-args.js
+++ b/lib/routeros-args.js
@@ -61,6 +61,15 @@ const CIDR = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1
 const IP_RANGE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)-(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
 const DURATION = /^\d+[smhdw]?$/;
 const INTEGER = /^\d{1,5}$/;
+// An http(s) endpoint this tool POSTs to from the device. Deliberately narrow:
+// no whitespace, quotes or backslashes, because the value is also written into
+// a generated RouterOS script that backup reads back by pattern.
+const HTTP_URL = /^https?:\/\/[^\s"'\\`]{1,250}$/;
+// A notification title. It is sent as an "X-Title:" header and RouterOS
+// separates several header fields with commas, so a comma would split it into
+// a second, malformed header. A quote would end the string literal in the
+// generated script that backup reads back by pattern.
+const NOTIFY_TITLE = /^[^",\r\n]{1,64}$/;
 
 const ifaceName = (v, what = 'interface name') => must(v, IDENTIFIER, what);
 const ipv4 = (v, what = 'IPv4 address') => must(v, IPV4, what);
@@ -83,8 +92,27 @@ function ipv4List(value, what = 'address list') {
   return clean.join(',');
 }
 
+/**
+ * Render a multi-line RouterOS script body as a quoted `source=` argument.
+ *
+ * Two things make this different from q(). A command is sent to the device as
+ * one line, so a real newline in the body would end the command mid-string;
+ * RouterOS spells a newline inside a quoted string as `\n`, so that is what has
+ * to go on the wire. And the body is code, so the `$` in `$cur` must survive:
+ * q() escapes it to `\$`, which RouterOS un-escapes back to `$` when it stores
+ * the source. Escaping first and rewriting newlines second keeps the two from
+ * interfering - by the time newlines are rewritten, every backslash that the
+ * body itself contained has already been doubled.
+ *
+ * @param {string} body - Script text with real newlines
+ * @returns {string} - Including the surrounding quotes
+ */
+function scriptSource(body) {
+  return `"${escapeMikroTik(String(body)).replace(/\r/g, '').replace(/\n/g, '\\n')}"`;
+}
+
 module.exports = {
-  q, must,
+  q, must, scriptSource,
   ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List,
-  IDENTIFIER, IPV4, CIDR, IP_RANGE, DURATION
+  IDENTIFIER, IPV4, CIDR, IP_RANGE, DURATION, HTTP_URL, NOTIFY_TITLE
 };

--- a/lib/validate-router.js
+++ b/lib/validate-router.js
@@ -7,12 +7,89 @@
  * deployment was applied with no validation at all.
  */
 
-const { CIDR, IPV4, IP_RANGE, DURATION, IDENTIFIER } = require('./routeros-args');
+const { CIDR, IPV4, IP_RANGE, DURATION, IDENTIFIER, HTTP_URL, NOTIFY_TITLE } = require('./routeros-args');
 const { normalizeWans } = require('./router');
 
 const VALID_WAN_TYPES = ['dhcp', 'static', 'pppoe', 'lte'];
 // Shape alone is not enough: 999.999.999.999/99 matched the old pattern.
 const CIDR_RE = CIDR;
+
+const DURATION_UNITS = { s: 1, m: 60, h: 3600, d: 86400, w: 604800 };
+
+/**
+ * Convert a RouterOS duration such as "30s" or "5m" to seconds.
+ * A bare number is seconds, which is how RouterOS reads it.
+ * @param {string} value
+ * @returns {number}
+ */
+function durationSeconds(value) {
+  const match = String(value).match(/^(\d+)([smhdw]?)$/);
+  if (!match) return NaN;
+  return parseInt(match[1], 10) * (DURATION_UNITS[match[2]] || 1);
+}
+
+/**
+ * Validate the optional `notify` block.
+ *
+ * Everything here ends up either in a device command or in the body of a
+ * generated RouterOS script, so the shapes are strict on purpose.
+ *
+ * @param {Object} notify - The notify block
+ * @param {string} label - Prefix for messages
+ * @param {string[]} errors - Collected errors, appended to
+ * @param {string[]} warnings - Collected warnings, appended to
+ */
+function validateNotify(notify, label, errors, warnings) {
+  if (typeof notify !== 'object' || Array.isArray(notify)) {
+    errors.push(`${label}: notify must be a mapping with at least a url`);
+    return;
+  }
+
+  if (!notify.url) {
+    errors.push(`${label}: notify.url is required (e.g. https://ntfy.sh/your-topic)`);
+  } else if (!HTTP_URL.test(String(notify.url))) {
+    errors.push(`${label}: notify.url '${notify.url}' must be an http:// or https:// URL with no spaces or quotes`);
+  } else if (/^http:\/\//.test(String(notify.url))) {
+    // For ntfy and most webhook services the URL itself is the credential.
+    warnings.push(
+      `${label}: notify.url is plain http, so the URL - which is usually the only secret ` +
+      'protecting the topic - crosses the internet in clear text. Prefer https.'
+    );
+  }
+
+  if (notify.title !== undefined && !NOTIFY_TITLE.test(String(notify.title))) {
+    errors.push(`${label}: notify.title '${notify.title}' must be 1-64 characters with no comma, quote or newline`);
+  }
+
+  if (notify.interval !== undefined) {
+    if (!DURATION.test(String(notify.interval))) {
+      errors.push(`${label}: notify.interval '${notify.interval}' must look like 30s, 5m or 1h`);
+    } else if (/^0+[smhdw]?$/.test(String(notify.interval))) {
+      errors.push(`${label}: notify.interval cannot be zero - the scheduler would never run`);
+    } else if (durationSeconds(notify.interval) < 10) {
+      // Measured on a Chateau LTE6: a POST to an unreachable endpoint took
+      // about 10 seconds to give up, and the tick blocks for that whole time.
+      warnings.push(
+        `${label}: notify.interval of ${notify.interval} is shorter than the time /tool fetch takes ` +
+        'to give up on an unreachable endpoint (~10s), so ticks would pile up during an outage.'
+      );
+    }
+  }
+
+  if (notify.checkCertificate !== undefined && typeof notify.checkCertificate !== 'boolean') {
+    errors.push(`${label}: notify.checkCertificate must be true or false`);
+  }
+
+  // A factory device has no CA certificates at all and often lacks the flash to
+  // import a bundle, so turning verification on is how you get a notifier that
+  // silently never delivers.
+  if (notify.checkCertificate === true) {
+    warnings.push(
+      `${label}: notify.checkCertificate is on, so /tool fetch verifies the TLS chain. ` +
+      'A device with no imported CA certificates (`/certificate print count-only` = 0) will fail every send.'
+    );
+  }
+}
 
 /**
  * Validate the lan and wan blocks of a router-role configuration.
@@ -41,6 +118,10 @@ function validateRouterConfig(config, label = 'Router') {
   // A DHCP server needs a LAN address to derive its network and gateway from.
   if (lan.dhcpServer && (!lan.address || !CIDR_RE.test(lan.address))) {
     errors.push(`${label}: lan.dhcpServer needs a valid lan.address to derive its network from`);
+  }
+
+  if (config.notify !== undefined) {
+    validateNotify(config.notify, label, errors, warnings);
   }
 
   if (!Array.isArray(wans) || wans.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/router.example.yaml
+++ b/router.example.yaml
@@ -111,6 +111,62 @@ wan:
   #   probe: 208.67.222.222
 
 # ---------------------------------------------------------------------------
+# WAN change notification (optional)
+# ---------------------------------------------------------------------------
+# Push a message when the active uplink changes - wired to LTE, and back.
+# Leave this block out and nothing is installed. Remove it later and the
+# notifier is removed from the device on the next apply.
+#
+# notify:
+#   url: https://ntfy.sh/your-topic-here
+#     A plain HTTP POST target. ntfy is the easy one, but any endpoint that
+#     accepts a POST works. The message body is:
+#       <router identity> WAN: <previous uplink> -> <current uplink>
+#     using the uplink NAMES from the wan: block above.
+#
+#   title: office router failover
+#     Optional. Sent as an "X-Title:" header, which ntfy shows as the
+#     notification title. No commas - RouterOS separates header fields with
+#     them. Other endpoints can ignore the header.
+#
+#   interval: 30s
+#     Optional, defaults to 30s. How often the device checks. Detection is
+#     therefore up to one interval slower than the failover itself. Keep it
+#     comfortably above 10s: that is roughly how long /tool fetch takes to
+#     give up on an unreachable endpoint, and the check blocks meanwhile.
+#
+#   checkCertificate: false
+#     Optional, defaults to false. A factory device has NO CA certificates
+#     (`/certificate print count-only` returns 0) and often lacks the flash to
+#     import a bundle, so verification is off unless you have imported one.
+#
+# What it installs: a `wan-notify` script and a scheduler of the same name,
+# both commented "router:wan-notify". Re-applying replaces them; anything else
+# on the device is left alone.
+#
+# How it remembers which uplink was last active: in the script's own comment,
+# `router:wan-notify state=<uplink>`. Not a `:global` - a global set by a
+# script the SCHEDULER runs is discarded before the next tick, so every tick
+# would notify again. (It looks fine when tested by hand, because
+# `/system script run` does keep globals. That is the trap.) A comment is
+# config, so it also survives a reboot, and it is written only on a real
+# change.
+#
+# The state advances only after the POST succeeds, so a failover that took the
+# internet with it retries on the next tick instead of losing the message.
+# Both outcomes are logged: `/log print where message~"wan-notify"`.
+#
+# FIRST, ON A DEVICE IN device-mode `home` (the Chateau LTE6 ships this way),
+# BOTH `fetch` AND `scheduler` ARE DISABLED. Applying tells you so and stops
+# at this feature. To unlock, on the device:
+#
+#     /system/device-mode/update scheduler=yes fetch=yes
+#
+# then power-cycle it or press the reset button WITHIN 5 MINUTES. RouterOS
+# wants proof of physical access; no tool can do it for you. Check the current
+# state with `/system/device-mode/print`.
+
+# ---------------------------------------------------------------------------
 # WiFi (optional)
 # ---------------------------------------------------------------------------
 # A router with no WiFi is valid. Leave these out and the radios are untouched.

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -141,7 +141,7 @@ test('comments render as ;;; lines, not comment="..."', () => {
 
 console.log('\n=== Backup record parsing (real device fixtures) ===');
 const { isDisabledRecord } = require('../lib/backup');
-const { splitDetailRecords } = require('../lib/router');
+const { splitDetailRecords, recordComment } = require('../lib/router');
 
 test('a disabled radio is detected from the X flag, not disabled=yes', () => {
   // print detail never emits disabled=yes; disabled is an X in the flag field.
@@ -359,7 +359,342 @@ test('a real production config validates cleanly', () => {
   assert.strictEqual(warn.length, 1, 'the probe/resolver overlap should still warn');
 });
 
+console.log('\n=== WAN failover notification: generated script ===');
+const {
+  wanNotifyScript, parseWanNotifyScript, parseDeviceMode, notifyLabel
+} = require('../lib/router');
+
+const notifyWans = normalizeWans([
+  { name: 'primary', interface: 'ether1', type: 'dhcp', distance: 1, probe: '8.8.8.8' },
+  { name: 'backup', interface: 'lte1', type: 'lte', distance: 2, probe: '1.1.1.1' }
+]);
+const script = wanNotifyScript(notifyWans, {
+  url: 'https://ntfy.sh/example-topic',
+  title: 'office router failover',
+  label: 'nick-office-router'
+});
+
+test('state lives in the script comment, never in a :global', () => {
+  // The trap this whole design exists for. A :global set by a script the
+  // SCHEDULER runs is discarded before the next tick - verified on hardware,
+  // the variable was absent from /system/script/environment entirely. It looks
+  // like it works when tested by hand, because /system/script/run DOES persist
+  // globals. A comment is config, so it also survives a reboot.
+  assert.ok(!/:global/.test(script), 'a :global would be discarded between scheduler ticks');
+  assert.ok(script.includes('/system script get $id comment'), 'state must be read from the comment');
+  assert.ok(script.includes('/system script set $id comment=$want'), 'state must be written to the comment');
+});
+test('the active uplink is read off the routes the role already writes', () => {
+  assert.ok(script.includes('/ip route find comment="wan:primary default" active=yes'));
+  assert.ok(script.includes('/ip route find comment="wan:backup default" active=yes'));
+});
+test('uplinks are tested worst-first so the preferred one wins', () => {
+  // Last assignment wins, so the lowest distance must come last.
+  assert.ok(script.indexOf('"wan:backup default"') < script.indexOf('"wan:primary default"'));
+});
+test('a total outage resolves to "none" rather than to the last uplink', () => {
+  assert.ok(/:local cur "none"/.test(script));
+});
+test('state advances only after the POST succeeds', () => {
+  // Otherwise a failover that took the internet with it loses its own
+  // notification: the send fails and the state moves on anyway.
+  const send = script.indexOf('/tool fetch');
+  const advance = script.indexOf('/system script set $id comment=$want');
+  const onError = script.indexOf('on-error=');
+  assert.ok(send > -1 && advance > send, 'the comment must be written after the fetch');
+  assert.ok(onError > advance, 'both must sit inside the :do block, before on-error');
+  assert.ok(/on-error=\{[\s\S]*will retry/.test(script), 'a failed send must say it will retry');
+});
+test('fetch writes no file and skips certificate checking by default', () => {
+  // A default device has no CA certificates and this one had 292KiB of flash
+  // free, so both of these are the difference between working and not.
+  assert.ok(/\/tool fetch [^\n]*output=none/.test(script));
+  assert.ok(/\/tool fetch [^\n]*check-certificate=no/.test(script));
+});
+test('checkCertificate: true turns verification back on', () => {
+  const strict = wanNotifyScript(notifyWans, { url: 'https://x.example/y', label: 'r', checkCertificate: true });
+  assert.ok(/check-certificate=yes/.test(strict));
+});
+test('a title becomes an X-Title header, and is omitted entirely when unset', () => {
+  assert.ok(script.includes(':local hdr ("X-Title: " . $title)'));
+  assert.ok(/\/tool fetch [^\n]*http-header-field=\$hdr/.test(script));
+  const untitled = wanNotifyScript(notifyWans, { url: 'https://x.example/y', label: 'r' });
+  assert.ok(!/http-header-field/.test(untitled), 'no title means no header argument at all');
+});
+test('the message names the router, so one topic can carry several', () => {
+  assert.ok(script.includes(':local msg ($label . " WAN: " . $prev . " -> " . $cur)'));
+  assert.ok(script.includes(':local label "nick-office-router"'));
+});
+test('notifyLabel prefers identity, then the hostname, and never an IP', () => {
+  assert.strictEqual(notifyLabel({ identity: 'gw1', host: 'other.example.net' }), 'gw1');
+  assert.strictEqual(notifyLabel({ host: 'nick-office-router.example.net' }), 'nick-office-router');
+  assert.strictEqual(notifyLabel({ host: '192.168.80.1' }), 'router');
+  assert.strictEqual(notifyLabel({}), 'router');
+});
+
+console.log('\n=== WAN failover notification: script encoding ===');
+const { scriptSource } = require('../lib/routeros-args');
+
+test('the script reaches the device as one line with escaped newlines', () => {
+  const wire = scriptSource(script);
+  assert.ok(!/\n/.test(wire), 'a real newline would end the command mid-string');
+  assert.ok(wire.includes('\\n'), 'newlines must be sent as the RouterOS \\n escape');
+});
+test('script variables survive the round trip through escaping', () => {
+  // q() escapes $ to \$, which is exactly right here: RouterOS un-escapes it
+  // when it stores the source, so the script still reads $cur, not \$cur.
+  const wire = scriptSource(':set cur $x');
+  assert.strictEqual(wire, '":set cur \\$x"');
+});
+test('a quote inside a value cannot break out of the generated script', () => {
+  const nasty = wanNotifyScript(notifyWans, { url: 'https://x.example/a"b', label: 'r' });
+  assert.ok(nasty.includes(':local url "https://x.example/a\\"b"'), 'inner literal is escaped');
+  assert.strictEqual(scriptSource('"'), '"\\""');
+});
+
+console.log('\n=== WAN failover notification: backup round trip ===');
+test('url, title and certificate checking are recovered from the source', () => {
+  const parsed = parseWanNotifyScript(script);
+  assert.strictEqual(parsed.url, 'https://ntfy.sh/example-topic');
+  assert.strictEqual(parsed.title, 'office router failover');
+  assert.strictEqual(parsed.checkCertificate, false);
+  assert.strictEqual(parseWanNotifyScript(wanNotifyScript(notifyWans, {
+    url: 'https://x.example/y', label: 'r', checkCertificate: true
+  })).checkCertificate, true);
+});
+test('an absent title reads back as absent, not as an empty string', () => {
+  assert.strictEqual(parseWanNotifyScript(wanNotifyScript(notifyWans, { url: 'https://x.example/y', label: 'r' })).title, null);
+});
+test('print detail carries the SOURCE, so state must be read from the field', () => {
+  // Captured shape from /system/script/print on a Chateau LTE6. A freshly
+  // installed notifier has no state yet, and grepping the whole record for
+  // state= then matches the code that WRITES the comment - yielding the
+  // fragment `"` rather than "no state recorded".
+  const fresh = ' 1   ;;; router:wan-notify\r\n' +
+    '     name="wan-notify" owner="admin" policy=read,write,test source=\r\n' +
+    '       :local want ("router:wan-notify state=" . $cur)\r\n';
+  assert.ok(/state=/.test(fresh), 'the blob does contain state=, which is the trap');
+  assert.strictEqual(recordComment(fresh).match(/state=(\S+)/), null, 'the comment field has no state yet');
+
+  const settled = fresh.replace(';;; router:wan-notify', ';;; router:wan-notify state=primary');
+  assert.strictEqual(recordComment(settled).match(/state=(\S+)/)[1], 'primary');
+});
+
+console.log('\n=== WAN failover notification: device-mode gate ===');
+test('an unlocked Chateau reports both features on', () => {
+  // Real output, /system/device-mode/print, RouterOS 7.18.2.
+  const real = '                 mode: home         \r\n     allowed-versions: 7.13+,6.49.8+\r\n' +
+    '            scheduler: yes           \r\n                socks: no           \r\n' +
+    '                fetch: yes           \r\n          routerboard: no           \r\n';
+  assert.deepStrictEqual(parseDeviceMode(real), { mode: 'home', scheduler: true, fetch: true });
+});
+test('a factory device in mode home blocks both, which is the shipped default', () => {
+  // Both off means /system/scheduler/add fails with "not allowed by
+  // device-mode" and /tool fetch fails the same way at runtime. Unlocking
+  // needs a physical power cycle, so the tool has to say so rather than
+  // surface the low-level failure.
+  const locked = '                 mode: home\r\n            scheduler: no\r\n                fetch: no\r\n';
+  assert.deepStrictEqual(parseDeviceMode(locked), { mode: 'home', scheduler: false, fetch: false });
+});
+test('one feature off is still reported precisely', () => {
+  assert.deepStrictEqual(parseDeviceMode('mode: enterprise\r\nscheduler: yes\r\nfetch: no\r\n'),
+    { mode: 'enterprise', scheduler: true, fetch: false });
+});
+test('a device that reports no device-mode at all yields null, not a false lock', () => {
+  assert.strictEqual(parseDeviceMode(''), null);
+  assert.strictEqual(parseDeviceMode('bad command name device-mode'), null);
+});
+
+console.log('\n=== WAN failover notification: validation ===');
+const notifyBase = {
+  lan: { address: '192.168.80.1/24', dns: { servers: ['9.9.9.9'] } },
+  wan: [{ name: 'primary', interface: 'ether1', probe: '8.8.8.8' }]
+};
+test('a minimal notify block is accepted', () => {
+  const { errors: e, warnings: w } = validateRouterConfig({ ...notifyBase, notify: { url: 'https://ntfy.sh/topic' } });
+  assert.deepStrictEqual(e, []);
+  assert.deepStrictEqual(w, []);
+});
+test('notify.url is required and must be an http(s) URL', () => {
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { title: 'x' } })
+    .errors.some(x => /notify.url is required/.test(x)));
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { url: 'ntfy.sh/topic' } })
+    .errors.some(x => /must be an http/.test(x)));
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { url: 'https://x/y" ; /user add name=z' } })
+    .errors.some(x => /must be an http/.test(x)));
+});
+test('a plain-http endpoint warns, because the URL is usually the credential', () => {
+  const { errors: e, warnings: w } = validateRouterConfig({ ...notifyBase, notify: { url: 'http://ntfy.sh/topic' } });
+  assert.deepStrictEqual(e, []);
+  assert.ok(w.some(x => /clear text/.test(x)));
+});
+test('a comma in the title is rejected - it would split the header field', () => {
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { url: 'https://x.example/y', title: 'a,b' } })
+    .errors.some(x => /notify.title/.test(x)));
+});
+test('a zero or malformed interval is rejected', () => {
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { url: 'https://x.example/y', interval: 'often' } })
+    .errors.some(x => /must look like 30s/.test(x)));
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: { url: 'https://x.example/y', interval: '0' } })
+    .errors.some(x => /cannot be zero/.test(x)));
+});
+test('an interval shorter than the fetch timeout warns about piling up', () => {
+  // Measured on hardware: a POST to a dead endpoint took ~10s to give up, and
+  // the tick blocks for that whole time.
+  const { errors: e, warnings: w } = validateRouterConfig({ ...notifyBase, notify: { url: 'https://x.example/y', interval: '5s' } });
+  assert.deepStrictEqual(e, []);
+  assert.ok(w.some(x => /pile up/.test(x)));
+  assert.deepStrictEqual(validateRouterConfig({ ...notifyBase, notify: { url: 'https://x.example/y', interval: '1m' } }).warnings, []);
+});
+test('turning certificate checking on warns about the empty certificate store', () => {
+  const { errors: e, warnings: w } = validateRouterConfig({
+    ...notifyBase, notify: { url: 'https://x.example/y', checkCertificate: true }
+  });
+  assert.deepStrictEqual(e, []);
+  assert.ok(w.some(x => /CA certificates/.test(x)));
+});
+test('notify must be a mapping', () => {
+  assert.ok(validateRouterConfig({ ...notifyBase, notify: 'https://x.example/y' })
+    .errors.some(x => /must be a mapping/.test(x)));
+});
+
+console.log('\n=== WAN failover notification: apply behaviour ===');
+const { configureWanNotify } = require('../lib/router');
+
+/**
+ * Minimal stand-in for a device, so the apply path can be exercised without
+ * one. It understands only the handful of command shapes configureWanNotify()
+ * issues, and records every command for assertions.
+ */
+function fakeDevice({ deviceMode = 'mode: home\r\nscheduler: yes\r\nfetch: yes\r\n',
+  scripts = [], schedulers = [] } = {}) {
+  const commands = [];
+  const listFor = kind => (kind === 'script' ? scripts : schedulers);
+  const terse = objects => objects.map((o, i) => `${i} name="${o.name}" comment="${o.comment || ''}"`).join('\n');
+
+  return {
+    commands, scripts, schedulers,
+    async exec(cmd) {
+      commands.push(cmd);
+      if (/device-mode/.test(cmd)) return deviceMode;
+
+      let m = cmd.match(/^:foreach s in=\[\/system script find comment~"([^"]+)"\]/);
+      if (m) {
+        return scripts.filter(s => new RegExp(m[1]).test(s.comment || '')).map(s => s.comment).join('\n');
+      }
+
+      m = cmd.match(/^\/system (script|scheduler) print terse where name="([^"]+)"/);
+      if (m) return terse(listFor(m[1]).filter(o => o.name === m[2]));
+
+      m = cmd.match(/^\/system (script|scheduler) print terse where comment="([^"]+)"/);
+      if (m) return terse(listFor(m[1]).filter(o => (o.comment || '') === m[2]));
+
+      m = cmd.match(/^\/system (script|scheduler) remove \[find comment(~|=)"([^"]+)"\]/);
+      if (m) {
+        const list = listFor(m[1]);
+        const keep = list.filter(o => (m[2] === '~'
+          ? !new RegExp(m[3]).test(o.comment || '')
+          : (o.comment || '') !== m[3]));
+        list.length = 0;
+        list.push(...keep);
+        return '';
+      }
+
+      m = cmd.match(/^\/system (script|scheduler) add name=(\S+)/);
+      if (m) {
+        const comment = cmd.match(/comment="((?:[^"\\]|\\.)*)"/);
+        listFor(m[1]).push({ name: m[2], comment: comment ? comment[1] : '', command: cmd });
+        return '';
+      }
+
+      return '';
+    }
+  };
+}
+
+const notifyConfig = { host: 'gw.example.net', notify: { url: 'https://ntfy.sh/topic', title: 'failover' } };
+
 (async () => {
+  const installed = fakeDevice();
+  const installProblems = await configureWanNotify(installed, notifyConfig, notifyWans);
+
+  test('a healthy device gets one script and one scheduler, both owned by comment', () => {
+    assert.deepStrictEqual(installProblems, []);
+    assert.strictEqual(installed.scripts.length, 1);
+    assert.strictEqual(installed.schedulers.length, 1);
+    assert.strictEqual(installed.scripts[0].name, 'wan-notify');
+    assert.strictEqual(installed.scripts[0].comment, 'router:wan-notify');
+    assert.strictEqual(installed.schedulers[0].comment, 'router:wan-notify');
+  });
+  test('the script and scheduler carry the policies /tool fetch needs', () => {
+    // Without `test` in the policy list, /tool fetch is refused at runtime.
+    assert.ok(/policy=read,write,test/.test(installed.scripts[0].command));
+    assert.ok(/policy=read,write,test/.test(installed.schedulers[0].command));
+  });
+  test('the scheduler runs the script at the configured interval', () => {
+    assert.ok(/interval=30s/.test(installed.schedulers[0].command), 'defaults to 30s');
+    assert.ok(installed.schedulers[0].command.includes('/system/script/run wan-notify'));
+  });
+
+  const restated = fakeDevice({
+    scripts: [{ name: 'wan-notify', comment: 'router:wan-notify state=primary' }],
+    schedulers: [{ name: 'wan-notify', comment: 'router:wan-notify' }]
+  });
+  await configureWanNotify(restated, notifyConfig, notifyWans);
+  test('re-applying keeps the recorded state, so an apply does not itself notify', () => {
+    assert.strictEqual(restated.scripts.length, 1, 'the old script is replaced, not duplicated');
+    assert.strictEqual(restated.scripts[0].comment, 'router:wan-notify state=primary');
+  });
+
+  const stale = fakeDevice({ scripts: [{ name: 'wan-notify', comment: 'router:wan-notify state=fibre' }] });
+  await configureWanNotify(stale, notifyConfig, notifyWans);
+  test('a state naming an uplink that no longer exists is dropped', () => {
+    // That really is a change worth announcing, so the next tick should send.
+    assert.strictEqual(stale.scripts[0].comment, 'router:wan-notify');
+  });
+
+  const locked = fakeDevice({ deviceMode: 'mode: home\r\nscheduler: no\r\nfetch: no\r\n' });
+  const lockedProblems = await configureWanNotify(locked, notifyConfig, notifyWans);
+  test('device-mode being locked is reported, and nothing is attempted', () => {
+    assert.strictEqual(lockedProblems.length, 1);
+    assert.ok(/device-mode blocks scheduler and fetch/.test(lockedProblems[0]));
+    assert.ok(/device-mode\/update scheduler=yes fetch=yes/.test(lockedProblems[0]), 'the fix must be in the message');
+    assert.ok(/power-cycle/.test(lockedProblems[0]), 'and so must the physical step');
+    assert.strictEqual(locked.scripts.length, 0);
+    assert.ok(!locked.commands.some(c => /add/.test(c)), 'no add is even attempted');
+  });
+
+  const clash = fakeDevice({ scripts: [{ name: 'wan-notify', comment: 'mine, hands off' }] });
+  const clashProblems = await configureWanNotify(clash, notifyConfig, notifyWans);
+  test('a wan-notify object this tool does not own is left alone', () => {
+    assert.strictEqual(clashProblems.length, 1);
+    assert.ok(/not commented/.test(clashProblems[0]));
+    assert.strictEqual(clash.scripts[0].comment, 'mine, hands off', 'the existing object survives');
+    assert.strictEqual(clash.schedulers.length, 0, 'and nothing is installed alongside it');
+  });
+
+  const removing = fakeDevice({
+    scripts: [{ name: 'wan-notify', comment: 'router:wan-notify state=primary' }],
+    schedulers: [{ name: 'wan-notify', comment: 'router:wan-notify' }]
+  });
+  const removeProblems = await configureWanNotify(removing, { host: 'gw.example.net' }, notifyWans);
+  test('deleting the notify block removes the notifier from the device', () => {
+    assert.deepStrictEqual(removeProblems, []);
+    assert.strictEqual(removing.scripts.length, 0);
+    assert.strictEqual(removing.schedulers.length, 0);
+  });
+
+  const rejected = fakeDevice();
+  const badProblems = await configureWanNotify(rejected, { host: 'gw.example.net', notify: { url: 'ftp://nope/x' } }, notifyWans);
+  test('a value that never passed validation stops before the device is touched', () => {
+    // configureRouter() is usable as a library function, so validation is not
+    // guaranteed to have run. Failing halfway would leave a script with no
+    // scheduler to run it.
+    assert.strictEqual(badProblems.length, 1);
+    assert.ok(/notify.url/.test(badProblems[0]));
+    assert.ok(!rejected.commands.some(c => /remove|add/.test(c)), 'nothing was removed or added');
+  });
+
   console.log('\n=== Host resolution (lockout guard) ===');
   const ip = await resolveHostAddress('192.168.80.1');
   test('an IP passes through unchanged', () => assert.strictEqual(ip, '192.168.80.1'));


### PR DESCRIPTION
Adds an optional `notify` block to `role: router`. When the active uplink changes — wired to LTE, and back — the device POSTs a short message to an endpoint you choose.

Failover being silent is the actual problem with it: the router moves to LTE, everything keeps working, and you find out weeks later from the data bill.

## Configuration

```yaml
role: router

notify:
  url: https://ntfy.sh/your-topic-here   # required; any http(s) POST target
  title: office router failover          # optional; sent as an X-Title header
  interval: 30s                          # optional; default 30s
  checkCertificate: false                # optional; default false
```

The message names the uplinks from your own `wan` block, prefixed with the router's identity so one topic can carry several routers:

```
nick-office-router WAN: primary -> backup
```

## What it installs

A `wan-notify` script and a scheduler of the same name, both commented `router:wan-notify` — the comment-ownership convention the rest of the router role uses. Re-applying replaces them and leaves everything else alone; an object of that name *without* that comment is reported and left untouched. Removing the block removes the notifier, so deleting the config really does turn it off. The settings round-trip through `backup-config.js`.

The active uplink is read from the routes the role already writes (`/ip route find comment="wan:<name> default" active=yes`), so there is no second source of truth about which uplink is preferred.

## State lives in the script's comment, not in a `:global`

This is the one detail that took hardware to get right.

**A `:global` set by a script the scheduler runs is discarded before the next tick.** After clearing the variable and letting the scheduler run repeatedly, it was absent from `/system/script/environment` entirely — so every tick would see "unknown" and notify again.

The trap is that the same script run by hand with `/system script run` *does* persist its globals, so the bug passes every interactive test.

State is therefore written into the script object's own comment, `router:wan-notify state=<uplink>`. That is configuration, so unlike a global it also survives a reboot, and it is written only when the uplink actually changes.

## A failed send is retried, not lost

The stored state advances only *after* the POST succeeds, so a failover that took the internet with it notifies as soon as the backup link is carrying traffic. Both outcomes are logged (`/log print where message~"wan-notify"`). A total outage resolves to the state `none`, a transition of its own rather than a stale "still on primary".

## RouterOS device-mode blocks this on a factory device

The Chateau LTE6 ships in `mode: home`, where **both `fetch` and `scheduler` are disabled**. `/system/scheduler/add` fails with "failure: not allowed by device-mode" and `/tool/fetch` fails the same way at runtime.

Applying now checks `/system/device-mode/print` first and stops at this feature with the fix spelled out — `/system/device-mode/update scheduler=yes fetch=yes`, then a physical power cycle or reset-button press within five minutes — rather than surfacing RouterOS's error. Everything else in the config is applied normally.

## Smaller decisions

- `check-certificate=no` by default: a factory device has zero CA certificates and the test device had ~292 KiB of flash free, far too little for a bundle. `checkCertificate: true` turns verification on and warns that an empty store will fail every send.
- `output=none` on the fetch, for the same flash reason.
- A comma in `title` is rejected — RouterOS separates `http-header-field` values with commas.
- An interval under 10 s warns: a POST to an unreachable endpoint took about ten seconds to give up, and the check blocks for that whole time.
- A plain `http://` endpoint warns, because for ntfy and most webhook services the URL *is* the credential.

## Testing

`npm test` — 86 assertions, up from 47. New coverage: the generated script (comment-based state, worst-first uplink ordering, state advancing only inside the `:do` block, `output=none`/`check-certificate`), `scriptSource()` encoding, backup round-trip, `parseDeviceMode()` against real captured output for both a locked and an unlocked device, validation, and the apply path itself against a fake device (install, re-apply keeping state, stale state dropped, device-mode locked, name clash, removal, pre-flight rejection).

Verified on a Chateau LTE6 (`D53G-5HacD2HnD&EG06-A`, RouterOS 7.18.2) against a local HTTP sink: the generated script round-tripped through escaping unchanged, resolved the active uplink from the live routes, delivered the POST with its `X-Title` header, advanced its comment, sent nothing at all on a second run, and — pointed at a dead endpoint — left the state untouched and logged that it would retry. Temporary objects were tagged `temp:` and removed.

Not verified on hardware: the notifier running under the scheduler end to end, since the test device is a live internet gateway. The design contains no `:global`, which is the failure mode a scheduler run would expose, and an equivalent hand-installed script has been running under a scheduler on that device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1