### PR TITLE
fix: clamp TCP MSS on WAN egress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,96 @@ const BAND_TO_INTERFACE = {
 - A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
 - A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
 
+**Router Role: MSS Clamping (on by default)**
+- ONE mangle rule on `chain=forward`, commented `router:mss-clamp`, matching
+  `out-interface-list=WAN` with `new-mss=clamp-to-pmtu`.
+- **Do NOT add a matching ingress rule.** `clamp-to-pmtu` derives the MSS from the route
+  toward the packet's DESTINATION. For a SYN-ACK matched on WAN ingress that destination
+  is the LAN bridge, normally 1500, so it would clamp to 1460 no matter how narrow the
+  uplink is. It looks like it covers the upload direction while doing nothing. An earlier
+  revision of this feature shipped exactly that rule; it was removed after review.
+- The upload direction is covered instead by the router's OWN ICMP "fragmentation needed"
+  back to the LAN client. That ICMP is generated locally, one hop away, so it is rarely
+  the one being filtered.
+- `new-mss=clamp-to-pmtu`, never a fixed value: a no-op on a 1500-byte uplink instead
+  of a permanent penalty. Verified valid syntax on RouterOS 7.18.2.
+- Opt-out via `lan.mssClamp: false`. Validation rejects a non-boolean, because the
+  setting is compared with `!== false` and a stringy `"false"` from YAML would read as
+  ON and silently do the opposite of what was written.
+- Objects are matched by EXACT comment, never `comment~"^router:mss-clamp"`. A prefix
+  pattern would also delete someone's `router:mss-clamp-custom`.
+- A rule that is already correct is left untouched. Re-applying does not remove and
+  re-add it, so a working gateway is never briefly unclamped.
+- Replacing a WRONG rule stages first: add under `router:mss-clamp-staged`, verify it
+  read back correct, remove the old rule, then rename the staged one. A drifted rule may
+  still be doing useful work (a fixed MSS beats no clamp), so it is never destroyed
+  before the replacement is proven to exist.
+- Recovery from an interrupted swap matters as much as the swap. If the process dies
+  after the canonical rule is removed but before promotion, the verified staged rule IS
+  the live clamp. The next apply ADOPTS it (renames it) rather than deleting it and
+  adding fresh - deleting a proven-good rule risks leaving the gateway with none if the
+  new add fails, which is the exact failure staging exists to prevent. Any other
+  stranded staged rule is cleared, and clearing it must SUCCEED before staging proceeds.
+- Two active clamp rules must never persist: a stranded staged rule is removed even when
+  the canonical rule is already correct.
+- The opt-out path removes BOTH comments and confirms BOTH are absent. Backup records
+  `mssClamp: false` only when BOTH are absent, so a mid-swap device is not recorded as
+  opted out - that would make the next apply deliberately remove a working rule.
+- `mssClampRuleIsCurrent()` compares EXACT field values, parsed as `key=value`, and
+  requires the rule to be enabled. Substring matching is not enough: `chain=forward-custom`
+  contains `chain=forward`, `out-interface-list=WAN-backup` contains `out-interface-list=WAN`,
+  and `tcp-flags=syn,!ack` contains `tcp-flags=syn`. All three look right and behave
+  differently. A rule carrying `in-interface`/`in-interface-list` is rejected outright.
+- Verification runs in BOTH states. Checking only when clamping is on would let a failed
+  removal pass while the rule is still live.
+- Backup records `mssClamp: false` only when the rule is absent. A read FAILURE is
+  left unrecorded rather than guessed at: writing `false` on error would silently strip
+  the clamp on the next apply.
+- This is a fix for uplinks where path MTU discovery is blocked (PPPoE at 1492, many
+  LTE bearers). It changes segment SIZE, never RATE. A slow uplink stays slow - see the
+  carrier-policer note below before blaming MSS for a throughput complaint.
+- NOT verified on a genuinely MTU-constrained uplink. The LTE bearer available for
+  testing reports and carries 1500 bytes, so `clamp-to-pmtu` had nothing to clamp.
+
+**Measuring A Backup WAN: The Router Does Not Use It (2026-08-25)**
+- The router's OWN traffic follows the main routing table, so it leaves via the ACTIVE
+  uplink. On a healthy router that is the wired WAN, never the LTE backup.
+- So `/tool/fetch` on the router does NOT test the backup link. It tests the primary.
+  A "router-originated over LTE" number collected that way is a wired number.
+- To force router traffic onto a backup uplink, mark it in `chain=output`:
+  ```
+  /routing/table add name=t-lte fib
+  /ip route add dst-address=0.0.0.0/0 gateway=lte1 routing-table=t-lte
+  /ip firewall mangle add chain=output dst-address=<test-ip> action=mark-routing \
+      new-routing-mark=t-lte passthrough=no
+  ```
+  Use `chain=prerouting src-address=<client>` for the same test from a LAN client. This
+  isolates one source/destination pair on the backup link with no outage.
+- Measure with `/interface get lte1 rx-byte` deltas, not with what the client reports.
+- `/tool/sniffer` and `/tool/torch` are blocked unless device-mode allows them. Counter
+  deltas, `/ping`, and firewall rule counters all still work and are usually enough.
+- `/tool/fetch ... output=user` silently CAPS the result at 64512 bytes. It looks like a
+  completed transfer. Use `output=none` to pull a whole file.
+
+**A Uniform Byte Rate Is A Carrier Policer, Not A Config Bug (2026-08-25)**
+- Symptom reported: LAN clients could not sustain a TCP transfer over the LTE backup.
+  Small requests fine, 1MB "stalled". Real cause: the SIM was policed to ~63 kbit/s.
+- What proved it, all measured on the live Chateau LTE6:
+  - Forwarded (chain=forward, masqueraded) 7.9 KB/s vs router-originated (chain=output)
+    8.1 KB/s. No forward-vs-output asymmetry at all.
+  - MSS swept 1360/1200/1000/800/536 -> throughput unchanged. Rules out path MTU.
+  - Disabling `router:forward-invalid` -> unchanged. Bypassing masquerade -> unchanged.
+    `change-ttl set:64` (carrier tethering detection) -> unchanged.
+  - APN swept `fast.t-mobile.com` / network-supplied / `h2g2`, and `ip-type=ipv4`. Each
+    produced a NEW bearer IP in a different block. All gave 7.68 KB/s. The cap follows
+    the SIM, not the session.
+  - Radio was healthy throughout: RSSI -54dBm, SINR 19dB, LTE B4@20MHz.
+- Discriminator worth reusing: ping the probe address DURING a transfer. RTT stayed
+  30-45ms with 0% loss while throughput sat at 63 kbit/s. A queue/shaper inflates RTT; a
+  policer drops without queueing. Flat RTT + low rate = policer = upstream, not local.
+- `h2g2` DID attach here, contrary to the older note above. It was simply as slow as the
+  rest, which is how it can look like it "did not work".
+
 **Router Role: Interface Lists and Comment Conventions**
 - Maintains the `WAN` and `LAN` interface lists that RouterOS defconf already uses. One NAT rule (`out-interface-list=WAN`) and one firewall rule cover every uplink.
 - The `WAN` list member comment is the AUTHORITATIVE record: `wan:<name> type=... distance=... probe=... [apn=...]`.

--- a/lib/router.js
+++ b/lib/router.js
@@ -988,6 +988,269 @@ async function configureNat(mt) {
   );
 }
 
+const MSS_CLAMP_COMMENT = 'router:mss-clamp';
+// Where a replacement is built before the old rule is removed, so a failed add
+// cannot leave a live gateway unclamped.
+const MSS_CLAMP_STAGED = 'router:mss-clamp-staged';
+
+// The rule we intend to exist, as EXACT field values. Compared field by field,
+// never by substring: `chain=forward-custom` contains `chain=forward`, and
+// `tcp-flags=syn,!ack` contains `tcp-flags=syn`, but neither behaves the same.
+//
+// ONE rule, on WAN egress. `clamp-to-pmtu` derives the MSS from the route
+// toward the packet's DESTINATION, so a matching rule on WAN ingress would
+// compute against the LAN bridge (normally 1500) and clamp to 1460 no matter
+// what the uplink's MTU is. It would look like it covered the upload direction
+// while doing nothing. The upload direction instead relies on the router's own
+// ICMP "fragmentation needed" back to the LAN client, which is generated one
+// hop away and so is rarely the reply being filtered.
+const MSS_CLAMP_FIELDS = {
+  chain: 'forward',
+  action: 'change-mss',
+  'new-mss': 'clamp-to-pmtu',
+  protocol: 'tcp',
+  'tcp-flags': 'syn',
+  'out-interface-list': WAN_LIST
+};
+
+// A rule carrying any of these is not ours to keep, however well the rest of
+// its fields match. An ingress match in particular is the mistake this feature
+// shipped once already.
+const MSS_CLAMP_FORBIDDEN = ['in-interface', 'in-interface-list'];
+
+/**
+ * Split `print terse` output into one string per record.
+ *
+ * Terse records are a single line each, unlike `print detail`, so
+ * splitDetailRecords() (which expects indented continuations) does not apply.
+ *
+ * @param {string} output - Raw terse output
+ * @returns {string[]} - One entry per record
+ */
+function terseRecords(output) {
+  if (!output) return [];
+  return output.split(/\r?\n/).filter(line => /^\s*\d+\s/.test(line));
+}
+
+/**
+ * Parse one terse record into its key=value fields.
+ *
+ * Quoted values may contain spaces, so a naive split on whitespace loses them.
+ *
+ * @param {string} record - One terse record
+ * @returns {Object} - Field map with quotes stripped
+ */
+function parseTerseRecord(record) {
+  const fields = {};
+  const pattern = /([a-zA-Z0-9-]+)=("(?:[^"\\]|\\.)*"|[^\s]*)/g;
+  let match;
+  while ((match = pattern.exec(record || '')) !== null) {
+    let value = match[2];
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+    fields[match[1]] = value;
+  }
+  return fields;
+}
+
+/**
+ * Is this terse record the clamp rule we want, and is it enabled?
+ *
+ * Every field must match EXACTLY. A substring test would accept a rule in
+ * `chain=forward-custom` or one matching `out-interface-list=WAN-backup`, which
+ * look right and behave differently. A comment-only test would additionally
+ * accept a hand-disabled rule - the exact silent failure this guards.
+ *
+ * @param {string} record - One terse record
+ * @returns {boolean}
+ */
+function mssClampRuleIsCurrent(record) {
+  if (!record || !record.trim()) return false;
+  // Terse records lead with an index then uppercase flag letters; X is
+  // disabled. Field names are lowercase, so they cannot be read as flags.
+  const flags = /^\s*\d+\s+([A-Z]+)\s/.exec(record);
+  if (flags && flags[1].includes('X')) return false;
+
+  const fields = parseTerseRecord(record);
+  if (MSS_CLAMP_FORBIDDEN.some(key => fields[key] !== undefined)) return false;
+  return Object.entries(MSS_CLAMP_FIELDS).every(([key, value]) => fields[key] === value);
+}
+
+/** Build the add command for a rule carrying the given comment. */
+function mssClampAddCommand(comment) {
+  const props = Object.entries(MSS_CLAMP_FIELDS).map(([k, v]) => `${k}=${v}`).join(' ');
+  return `/ip firewall mangle add ${props} passthrough=yes comment=${q(comment)}`;
+}
+
+/**
+ * Clamp the TCP MSS of forwarded connections to the path MTU.
+ *
+ * An uplink whose MTU is below 1500 - PPPoE at 1492, some LTE bearers - relies
+ * on path MTU discovery to stop endpoints sending frames too big for the link.
+ * PMTU discovery breaks whenever a hop on the way drops the ICMP
+ * "fragmentation needed" reply, and plenty of them do. The connection then
+ * completes its handshake and dies as soon as a full-size segment appears,
+ * which reads as "small requests work, large transfers stall".
+ *
+ * Clamping on the SYN sidesteps the ICMP round trip: the far end is told up
+ * front how much it may send. `clamp-to-pmtu` lowers the MSS to fit the
+ * outgoing link and leaves it alone when it already fits, so this is a no-op on
+ * a 1500-byte uplink rather than a fixed penalty.
+ *
+ * NOTE: this is not a throughput fix. It changes segment size, never rate. An
+ * uplink that is slow stays slow.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {boolean} enabled - Whether the clamp should be installed
+ * @returns {Promise<string[]>} - Unmet requirements, for the postcondition list
+ */
+async function configureMssClamp(mt, enabled) {
+  const problems = [];
+  const find = `[find comment=${q(MSS_CLAMP_COMMENT)}]`;
+  const findStaged = `[find comment=${q(MSS_CLAMP_STAGED)}]`;
+  const show = `/ip firewall mangle print terse where comment=${q(MSS_CLAMP_COMMENT)}`;
+  const showStaged = `/ip firewall mangle print terse where comment=${q(MSS_CLAMP_STAGED)}`;
+
+  if (!enabled) {
+    console.log('\n=== Removing MSS Clamp ===');
+    for (const target of [find, findStaged]) {
+      try {
+        await mt.exec(`/ip firewall mangle remove ${target}`);
+      } catch (e) {
+        problems.push(`Could not remove the MSS clamp rule: ${e.message}`);
+      }
+    }
+    // Confirm, do not assume. Swallowing a removal error and reporting a clean
+    // apply while the rule is still live is the failure worth guarding against.
+    try {
+      const leftover = [
+        ...terseRecords(await mt.exec(show)),
+        ...terseRecords(await mt.exec(showStaged))
+      ];
+      if (leftover.length > 0) {
+        problems.push('MSS clamp rule is still present after removal');
+      } else {
+        console.log('✓ MSS clamping off, no rule present');
+        console.log('   A PPPoE or LTE uplink may stall large transfers if path');
+        console.log('   MTU discovery is blocked along the way.');
+      }
+    } catch (e) {
+      problems.push(`Could not confirm the MSS clamp rule was removed: ${e.message}`);
+    }
+    return problems;
+  }
+
+  console.log('\n=== Configuring MSS Clamp ===');
+
+  let existing;
+  try {
+    existing = terseRecords(await mt.exec(show));
+  } catch (e) {
+    problems.push(`Could not read the MSS clamp rule: ${e.message}`);
+    return problems;
+  }
+
+  let staged;
+  try {
+    staged = terseRecords(await mt.exec(showStaged));
+  } catch (e) {
+    problems.push(`Could not read the staged MSS clamp rule: ${e.message}`);
+    return problems;
+  }
+
+  // Leave a correct rule alone. Removing and re-adding it every run would churn
+  // the firewall and leave the gateway briefly unclamped for no reason.
+  if (existing.length === 1 && mssClampRuleIsCurrent(existing[0])) {
+    if (staged.length > 0) {
+      try {
+        await mt.exec(`/ip firewall mangle remove ${findStaged}`);
+      } catch (e) {
+        // Two active clamp rules would otherwise pass verification unnoticed.
+        problems.push(`Could not remove a stranded staged MSS clamp rule: ${e.message}`);
+      }
+    }
+    console.log('✓ MSS clamp already correct');
+    return problems;
+  }
+
+  // Interrupted mid-swap: the canonical rule was removed and the process died
+  // before promotion, so the verified staged rule IS the live clamp. Adopt it.
+  // Deleting it and adding fresh would destroy a proven-good rule and leave the
+  // gateway unclamped if that add then failed - the exact failure staging is
+  // meant to prevent.
+  if (existing.length === 0 && staged.length === 1 && mssClampRuleIsCurrent(staged[0])) {
+    try {
+      await mt.exec(`/ip firewall mangle set ${findStaged} comment=${q(MSS_CLAMP_COMMENT)}`);
+      console.log('✓ Adopted a staged MSS clamp rule left by an interrupted run');
+    } catch (e) {
+      problems.push(`Could not adopt the staged MSS clamp rule: ${e.message}`);
+    }
+    return problems;
+  }
+
+  // Anything else stranded is not usable. Clearing it must SUCCEED, otherwise
+  // staging would collide with it.
+  if (staged.length > 0) {
+    try {
+      await mt.exec(`/ip firewall mangle remove ${findStaged}`);
+    } catch (e) {
+      problems.push(`Could not clear a stranded staged MSS clamp rule: ${e.message}`);
+      return problems;
+    }
+  }
+
+  if (existing.length === 0) {
+    // Nothing to lose: add directly under the real comment.
+    try {
+      await mt.exec(mssClampAddCommand(MSS_CLAMP_COMMENT));
+      console.log('✓ MSS clamp on WAN egress (clamp-to-pmtu)');
+    } catch (e) {
+      problems.push(`Could not add the MSS clamp rule: ${e.message}`);
+    }
+    return problems;
+  }
+
+  // Something is there but wrong. It may still be doing useful work - a rule
+  // with a fixed MSS is worse than clamp-to-pmtu but far better than nothing -
+  // so prove the replacement installs BEFORE removing it.
+  try {
+    await mt.exec(mssClampAddCommand(MSS_CLAMP_STAGED));
+  } catch (e) {
+    problems.push(`Could not stage a replacement MSS clamp rule, left the existing one in place: ${e.message}`);
+    return problems;
+  }
+
+  try {
+    const staged = terseRecords(await mt.exec(showStaged));
+    if (staged.length !== 1 || !mssClampRuleIsCurrent(staged[0])) {
+      throw new Error('the staged rule did not read back as expected');
+    }
+  } catch (e) {
+    problems.push(`Staged MSS clamp rule failed verification, left the existing one in place: ${e.message}`);
+    try {
+      await mt.exec(`/ip firewall mangle remove ${findStaged}`);
+    } catch (cleanupError) {
+      problems.push(`Could not remove the staged MSS clamp rule: ${cleanupError.message}`);
+    }
+    return problems;
+  }
+
+  try {
+    await mt.exec(`/ip firewall mangle remove ${find}`);
+  } catch (e) {
+    problems.push(`Could not remove the outdated MSS clamp rule: ${e.message}`);
+    return problems;
+  }
+
+  try {
+    await mt.exec(`/ip firewall mangle set ${findStaged} comment=${q(MSS_CLAMP_COMMENT)}`);
+    console.log('✓ MSS clamp replaced on WAN egress (clamp-to-pmtu)');
+  } catch (e) {
+    problems.push(`Could not promote the staged MSS clamp rule: ${e.message}`);
+  }
+
+  return problems;
+}
+
 /**
  * Build the input and forward chains.
  *
@@ -1660,6 +1923,22 @@ async function backupRouterConfig(mt) {
     }
   } catch (e) { /* absent */ }
 
+  // MSS clamping is opt-OUT, so only record it when someone has turned it off.
+  // Recording the default would bloat every backup with a line that changes
+  // nothing. Read failures are left unrecorded rather than guessed at: writing
+  // mssClamp:false here would silently strip the clamp on the next apply.
+  try {
+    // Check the staged comment too. Mid-swap, the canonical rule is gone but a
+    // verified staged rule is the live clamp; recording mssClamp:false there
+    // would make the next apply deliberately remove a working rule.
+    const clamp = await mt.exec(`/ip firewall mangle print terse where comment=${q(MSS_CLAMP_COMMENT)}`);
+    const stagedClamp = await mt.exec(`/ip firewall mangle print terse where comment=${q(MSS_CLAMP_STAGED)}`);
+    if (terseRecords(clamp).length === 0 && terseRecords(stagedClamp).length === 0) {
+      lan.mssClamp = false;
+      console.log('\u2713 MSS clamping disabled');
+    }
+  } catch (e) { /* leave at the default */ }
+
   const notify = await backupWanNotify(mt);
 
   return notify ? { lan, wan, notify } : { lan, wan };
@@ -1852,6 +2131,21 @@ async function verifyRouterState(mt, lan) {
     out => out.includes('router:input-lan')
   );
 
+  // Checked in BOTH states. Skipping the check when clamping is off would let a
+  // failed removal pass verification with the rule still live.
+  await check(
+    lan.mssClamp === false
+      ? 'MSS clamp is absent (mssClamp: false)'
+      : 'MSS clamp is installed and enabled on WAN egress',
+    `/ip firewall mangle print terse where comment=${q(MSS_CLAMP_COMMENT)}`,
+    out => {
+      const records = terseRecords(out);
+      return lan.mssClamp === false
+        ? records.length === 0
+        : records.length === 1 && mssClampRuleIsCurrent(records[0]);
+    }
+  );
+
   if (lan.dhcpServer) {
     await check(
       'DHCP server is running on the bridge',
@@ -1911,6 +2205,7 @@ async function configureRouter(config = {}) {
     await configureFailoverRoutes(mt, wans);
     await configureNat(mt);
     await configureRouterFirewall(mt, lanListVerified, lan.fasttrack === true);
+    const mssProblems = await configureMssClamp(mt, lan.mssClamp !== false);
 
     // The DHCP server and its network entry only make sense once the bridge
     // actually holds the LAN address, so add it before they are created.
@@ -1935,7 +2230,7 @@ async function configureRouter(config = {}) {
       console.log('\n⚠️  Skipping stale-address cleanup because the LAN address was not added.');
     }
 
-    const problems = [...(await verifyRouterState(mt, lan)), ...notifyProblems];
+    const problems = [...(await verifyRouterState(mt, lan)), ...mssProblems, ...notifyProblems];
     if (problems.length > 0) {
       console.log('\n========================================');
       console.log('✗ Router Configuration INCOMPLETE');
@@ -1977,6 +2272,11 @@ module.exports = {
   removeStaleLanAddresses,
   backupRouterConfig,
   configureRouterWifi,
+  configureMssClamp,
+  mssClampRuleIsCurrent,
+  parseTerseRecord,
+  terseRecords,
+  MSS_CLAMP_COMMENT,
   splitDetailRecords,
   recordComment,
   resolveHostAddress,

--- a/lib/validate-router.js
+++ b/lib/validate-router.js
@@ -132,6 +132,12 @@ function validateRouterConfig(config, label = 'Router') {
   if (lan.ports !== undefined && !Array.isArray(lan.ports)) {
     errors.push(`${label}: lan.ports must be a list`);
   }
+  // Guard the type explicitly. `mssClamp` defaults to on and is compared with
+  // `!== false`, so a stringy "false" from YAML would read as ON and silently
+  // do the opposite of what was written.
+  if (lan.mssClamp !== undefined && typeof lan.mssClamp !== 'boolean') {
+    errors.push(`${label}: lan.mssClamp must be true or false`);
+  }
   if (lan.dns?.servers !== undefined && !Array.isArray(lan.dns.servers)) {
     errors.push(`${label}: lan.dns.servers must be a list`);
   }

--- a/router.example.yaml
+++ b/router.example.yaml
@@ -58,6 +58,17 @@ lan:
   # failover cleanliness.
   # fasttrack: true
 
+  # TCP MSS clamping, on by default. An uplink narrower than 1500 bytes - PPPoE
+  # at 1492, most LTE bearers - needs each end told how much it may send. The
+  # normal way to learn that is path MTU discovery, which relies on an ICMP
+  # reply that many networks drop. When it is dropped, connections open and then
+  # die on the first full-size segment: small requests work, large ones stall.
+  # Clamping the outbound SYN says the limit up front, so the far end never
+  # sends a segment too big for the uplink.
+  # It costs nothing on a 1500-byte uplink, where it clamps to the same value.
+  # This changes segment size, never rate. A slow uplink stays slow.
+  # mssClamp: false
+
 # ---------------------------------------------------------------------------
 # WAN
 # ---------------------------------------------------------------------------

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -13,7 +13,8 @@ const assert = require('assert');
 const {
   parseCidr, cidrContains, networkOf, defaultPoolFor,
   normalizeWans, wanMemberComment, parseWanMemberComment,
-  resolveHostAddress
+  resolveHostAddress, configureMssClamp, mssClampRuleIsCurrent, terseRecords,
+  parseTerseRecord
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
 const { validateRouterConfig } = require('../lib/validate-router');
@@ -614,6 +615,66 @@ function fakeDevice({ deviceMode = 'mode: home\r\nscheduler: yes\r\nfetch: yes\r
 
 const notifyConfig = { host: 'gw.example.net', notify: { url: 'https://ntfy.sh/topic', title: 'failover' } };
 
+console.log('\n=== MSS clamp validation ===');
+test('mssClamp accepts booleans and rejects anything else', () => {
+  const base = { lan: { address: '192.168.80.1/24' }, wan: [{ name: 'a', interface: 'ether1', type: 'dhcp' }] };
+  const ok = validateRouterConfig({ ...base, lan: { ...base.lan, mssClamp: false } });
+  assert.deepStrictEqual(ok.errors, [], `expected no errors, got: ${ok.errors.join('; ')}`);
+  // A stringy "false" out of YAML would pass the `!== false` check and clamp
+  // anyway, doing the opposite of what was written. It has to be rejected.
+  const bad = validateRouterConfig({ ...base, lan: { ...base.lan, mssClamp: 'false' } });
+  assert.ok(bad.errors.some(e => /mssClamp/.test(e)), 'a non-boolean mssClamp should be an error');
+});
+test('terseRecords counts records, not blank lines or headers', () => {
+  assert.strictEqual(terseRecords('').length, 0);
+  assert.strictEqual(terseRecords('Flags: X - disabled\n\n').length, 0, 'a header alone is not a record');
+  assert.strictEqual(terseRecords(' 0    chain=forward \n 1    chain=forward ').length, 2);
+});
+
+test('parseTerseRecord keeps quoted values whole', () => {
+  const f = parseTerseRecord(' 0    chain=forward comment="router:mss-clamp" protocol=tcp ');
+  assert.strictEqual(f.chain, 'forward');
+  assert.strictEqual(f.comment, 'router:mss-clamp', 'quotes must be stripped, value kept intact');
+  assert.strictEqual(f.protocol, 'tcp');
+});
+
+test('mssClampRuleIsCurrent rejects anything that is not the exact live rule', () => {
+  const ok = ' 0    chain=forward action=change-mss new-mss=clamp-to-pmtu passthrough=yes'
+    + ' protocol=tcp tcp-flags=syn out-interface-list=WAN comment="router:mss-clamp" ';
+  assert.ok(mssClampRuleIsCurrent(ok), 'the correct rule should be accepted');
+  // A disabled rule matches every field but does nothing. Accepting it is
+  // precisely the silent failure this predicate exists to prevent.
+  assert.ok(!mssClampRuleIsCurrent(ok.replace(' 0    ', ' 0  X ')), 'disabled must be rejected');
+  assert.ok(!mssClampRuleIsCurrent(''), 'empty is not a rule');
+
+  // SUPERSETS AND PREFIXES. These are the dangerous ones: each CONTAINS the
+  // expected text, so any substring-based check waves them through even though
+  // every one of them behaves differently from the intended rule.
+  const supersets = [
+    ['chain=forward', 'chain=forward-custom'],
+    ['out-interface-list=WAN', 'out-interface-list=WAN-backup'],
+    ['tcp-flags=syn', 'tcp-flags=syn,!ack'],
+    ['action=change-mss', 'action=change-mss-custom'],
+    ['new-mss=clamp-to-pmtu', 'new-mss=clamp-to-pmtu-ish']
+  ];
+  for (const [from, to] of supersets) {
+    assert.ok(!mssClampRuleIsCurrent(ok.replace(from, to)), `must reject ${to}`);
+  }
+
+  // An ingress match is the mistake this feature shipped once already, so a
+  // rule carrying one is rejected however well its other fields match.
+  assert.ok(!mssClampRuleIsCurrent(ok.replace('passthrough=yes', 'passthrough=yes in-interface-list=WAN')),
+    'a rule with an ingress match must be rejected');
+});
+
+test('omitting mssClamp is valid and leaves it on', () => {
+  const { errors: e } = validateRouterConfig({
+    lan: { address: '192.168.80.1/24' },
+    wan: [{ name: 'a', interface: 'ether1', type: 'dhcp' }]
+  });
+  assert.deepStrictEqual(e, [], `expected no errors, got: ${e.join('; ')}`);
+});
+
 (async () => {
   const installed = fakeDevice();
   const installProblems = await configureWanNotify(installed, notifyConfig, notifyWans);
@@ -693,6 +754,206 @@ const notifyConfig = { host: 'gw.example.net', notify: { url: 'https://ntfy.sh/t
     assert.strictEqual(badProblems.length, 1);
     assert.ok(/notify.url/.test(badProblems[0]));
     assert.ok(!rejected.commands.some(c => /remove|add/.test(c)), 'nothing was removed or added');
+  });
+
+  console.log('\n=== MSS clamp commands ===');
+
+  // A fake that can FAIL, and that tells the canonical query apart from the
+  // staged one. The clamp's job is to leave a live firewall in a known state,
+  // so the paths worth testing are the ones where a command errors or the
+  // device answers unexpectedly - not the happy path.
+  const RULE = ' 0    chain=forward action=change-mss new-mss=clamp-to-pmtu passthrough=yes'
+    + ' protocol=tcp tcp-flags=syn out-interface-list=WAN comment="router:mss-clamp" ';
+  const CANON_Q = 'comment="router:mss-clamp"';
+  const STAGED_Q = 'comment="router:mss-clamp-staged"';
+
+  // responses: [substringToMatch, replyOrError][] - first match wins, so list
+  // the staged query first (the canonical needle ends in a quote, so the two
+  // never collide, but explicit ordering documents the intent).
+  const device = (responses = []) => {
+    const sent = [];
+    return {
+      sent,
+      exec: async cmd => {
+        sent.push(cmd);
+        for (const [needle, reply] of responses) {
+          if (cmd.includes(needle)) {
+            if (reply instanceof Error) throw reply;
+            return reply;
+          }
+        }
+        return '';
+      }
+    };
+  };
+  const adds = d => d.sent.filter(c => c.includes('mangle add'));
+  const removesCanon = d => d.sent.filter(c => c.includes('mangle remove') && c.includes(CANON_Q));
+  const removesStaged = d => d.sent.filter(c => c.includes('mangle remove') && c.includes(STAGED_Q));
+
+  const fresh = device();
+  const freshProblems = await configureMssClamp(fresh, true);
+  test('a device with no rule gets one directly, with no staging dance', () => {
+    assert.deepStrictEqual(freshProblems, []);
+    assert.strictEqual(adds(fresh).length, 1, 'expected exactly one add');
+    assert.ok(adds(fresh)[0].includes(CANON_Q), 'a fresh add goes straight to the real comment');
+    assert.strictEqual(removesCanon(fresh).length, 0, 'there is no existing rule to remove');
+  });
+  test('the rule is a single WAN-egress rule, never an ingress one', () => {
+    const cmd = adds(fresh)[0];
+    assert.ok(cmd.includes('out-interface-list=WAN'), 'must clamp on WAN egress');
+    // clamp-to-pmtu computes from the route to the DESTINATION, so an ingress
+    // rule would clamp against the LAN bridge and quietly do nothing.
+    assert.ok(!cmd.includes('in-interface'), 'must NOT add an ingress rule');
+    assert.ok(cmd.includes('new-mss=clamp-to-pmtu'), 'a fixed MSS penalises a 1500 uplink');
+    assert.ok(/chain=forward/.test(cmd) && /tcp-flags=syn/.test(cmd));
+  });
+  test('objects are matched by EXACT comment, not a prefix pattern', () => {
+    // "~^router:mss-clamp" would also delete router:mss-clamp-custom.
+    for (const cmd of fresh.sent) {
+      assert.ok(!cmd.includes('~'), `must not use a regex match: ${cmd}`);
+    }
+  });
+
+  const correct = device([[CANON_Q, RULE]]);
+  const correctProblems = await configureMssClamp(correct, true);
+  test('an already-correct rule is left completely alone', () => {
+    assert.deepStrictEqual(correctProblems, []);
+    assert.strictEqual(adds(correct).length, 0, 're-applying must not churn the firewall');
+    assert.strictEqual(correct.sent.filter(c => c.includes('mangle remove')).length, 0,
+      'must not briefly unclamp a working gateway');
+  });
+
+  for (const [label, record] of [
+    ['disabled by hand', RULE.replace(' 0    ', ' 0  X ')],
+    ['edited to a fixed MSS', RULE.replace('new-mss=clamp-to-pmtu', 'new-mss=1360')],
+    ['moved to another chain', RULE.replace('chain=forward', 'chain=output')]
+  ]) {
+    const drifted = device([[STAGED_Q, RULE], [CANON_Q, record]]);
+    const problems = await configureMssClamp(drifted, true);
+    test(`a rule ${label} is replaced via staging, old rule removed last`, () => {
+      assert.deepStrictEqual(problems, []);
+      const order = drifted.sent.map((c, i) => [i, c]);
+      const stagedAdd = order.find(([, c]) => c.includes('mangle add') && c.includes(STAGED_Q));
+      const canonRemove = order.find(([, c]) => c.includes('mangle remove') && c.includes(CANON_Q));
+      const promote = order.find(([, c]) => c.includes('mangle set') && c.includes(STAGED_Q));
+      assert.ok(stagedAdd, 'the replacement must be staged first');
+      assert.ok(canonRemove, 'the old rule must be removed');
+      assert.ok(promote, 'the staged rule must be promoted to the real comment');
+      // The whole point: never destroy the working rule before the replacement
+      // is proven to exist.
+      assert.ok(stagedAdd[0] < canonRemove[0], 'staged add must precede removing the old rule');
+      assert.ok(canonRemove[0] < promote[0], 'promotion must come after removal');
+    });
+  }
+
+  const stageFails = device([
+    [STAGED_Q, RULE],
+    [CANON_Q, RULE.replace('new-mss=clamp-to-pmtu', 'new-mss=1360')]
+  ]);
+  // Make only the staged ADD fail.
+  const origExec = stageFails.exec;
+  stageFails.exec = async cmd => {
+    if (cmd.includes('mangle add')) { stageFails.sent.push(cmd); throw new Error('no such command'); }
+    return origExec(cmd);
+  };
+  const stageProblems = await configureMssClamp(stageFails, true);
+  test('a failed staged add leaves the existing rule in place', () => {
+    assert.strictEqual(stageProblems.length, 1, `expected one problem, got: ${stageProblems}`);
+    assert.ok(/left the existing one in place/i.test(stageProblems[0]), stageProblems[0]);
+    // A fixed-MSS rule is worse than clamp-to-pmtu but far better than nothing.
+    assert.strictEqual(removesCanon(stageFails).length, 0, 'the working rule must survive');
+  });
+
+  const stageBad = device([
+    [STAGED_Q, RULE.replace('chain=forward', 'chain=output')],
+    [CANON_Q, RULE.replace('new-mss=clamp-to-pmtu', 'new-mss=1360')]
+  ]);
+  const stageBadProblems = await configureMssClamp(stageBad, true);
+  test('a staged rule that reads back wrong is cleaned up, old rule kept', () => {
+    assert.ok(stageBadProblems.some(p => /failed verification/i.test(p)), stageBadProblems.join('; '));
+    assert.strictEqual(removesCanon(stageBad).length, 0, 'the existing rule must survive');
+    assert.ok(removesStaged(stageBad).length >= 1, 'the bad staged rule must be cleaned up');
+  });
+
+  // Interrupted mid-swap: canonical removed, staged verified and live.
+  const interrupted = device([[STAGED_Q, RULE], [CANON_Q, '']]);
+  const interruptedProblems = await configureMssClamp(interrupted, true);
+  test('an interrupted swap adopts the staged rule instead of rebuilding', () => {
+    assert.deepStrictEqual(interruptedProblems, []);
+    // Deleting a proven-good rule to add a fresh one would leave the gateway
+    // unclamped if that add failed - the failure staging exists to prevent.
+    assert.strictEqual(removesStaged(interrupted).length, 0, 'must not destroy the live clamp');
+    assert.strictEqual(adds(interrupted).length, 0, 'must not add a duplicate');
+    assert.ok(interrupted.sent.some(c => c.includes('mangle set') && c.includes(STAGED_Q)),
+      'the staged rule must be promoted to the canonical comment');
+  });
+
+  // Stranded staged rule that is NOT usable: clearing it must succeed.
+  const strandedBad = device([
+    [STAGED_Q, RULE.replace('chain=forward', 'chain=output')],
+    [CANON_Q, '']
+  ]);
+  const origStranded = strandedBad.exec;
+  strandedBad.exec = async cmd => {
+    if (cmd.includes('mangle remove') && cmd.includes(STAGED_Q)) {
+      strandedBad.sent.push(cmd);
+      throw new Error('permission denied');
+    }
+    return origStranded(cmd);
+  };
+  const strandedProblems = await configureMssClamp(strandedBad, true);
+  test('a stranded staged rule that cannot be cleared stops the apply', () => {
+    assert.ok(strandedProblems.some(p => /stranded/i.test(p)), strandedProblems.join('; '));
+    assert.strictEqual(adds(strandedBad).length, 0, 'must not stage on top of a collision');
+  });
+
+  // A correct canonical rule PLUS a stranded staged one: the duplicate must go.
+  const dupe = device([[STAGED_Q, RULE], [CANON_Q, RULE]]);
+  const dupeProblems = await configureMssClamp(dupe, true);
+  test('a stranded staged rule is cleared even when the real rule is correct', () => {
+    assert.deepStrictEqual(dupeProblems, []);
+    assert.strictEqual(removesStaged(dupe).length, 1, 'two active clamp rules must not persist');
+    assert.strictEqual(adds(dupe).length, 0);
+  });
+
+  const readFails = device([[CANON_Q, new Error('timeout')]]);
+  const readProblems = await configureMssClamp(readFails, true);
+  test('a failed read stops before touching the firewall', () => {
+    assert.strictEqual(readProblems.length, 1);
+    assert.strictEqual(adds(readFails).length, 0, 'must not add blind');
+    assert.strictEqual(readFails.sent.filter(c => c.includes('mangle remove')).length, 0,
+      'must not remove blind');
+  });
+
+  const off = device();
+  const offProblems = await configureMssClamp(off, false);
+  test('opting out removes the rule and confirms it is gone', () => {
+    assert.deepStrictEqual(offProblems, []);
+    assert.strictEqual(removesCanon(off).length, 1);
+    assert.strictEqual(adds(off).length, 0);
+    assert.ok(off.sent.some(c => c.includes('mangle print')), 'removal must be verified, not assumed');
+  });
+
+  const offStuckStaged = device([[STAGED_Q, RULE], [CANON_Q, '']]);
+  const stuckStagedProblems = await configureMssClamp(offStuckStaged, false);
+  test('opting out also notices a surviving STAGED rule', () => {
+    // Checking only the canonical comment would report a clean opt-out while a
+    // staged rule was still clamping.
+    assert.ok(stuckStagedProblems.some(p => /still present/i.test(p)),
+      stuckStagedProblems.join('; '));
+  });
+
+  const offStuck = device([[CANON_Q, RULE]]);
+  const stuckProblems = await configureMssClamp(offStuck, false);
+  test('opting out reports failure when the rule survives removal', () => {
+    // Reporting a clean apply while the rule is still live is the worst case.
+    assert.ok(stuckProblems.some(p => /still present/i.test(p)), stuckProblems.join('; '));
+  });
+
+  const offErrors = device([['mangle remove', new Error('permission denied')]]);
+  const offErrProblems = await configureMssClamp(offErrors, false);
+  test('opting out reports a removal error instead of swallowing it', () => {
+    assert.ok(/could not remove/i.test(offErrProblems.join('; ')), offErrProblems.join('; '));
   });
 
   console.log('\n=== Host resolution (lockout guard) ===');


### PR DESCRIPTION
## Problem

The router role installed **no MSS clamp at all**.

An uplink whose MTU is below 1500 — PPPoE at 1492, some LTE bearers — depends on path MTU discovery to stop endpoints sending frames the link cannot carry. PMTU discovery breaks whenever a hop drops the ICMP "fragmentation needed" reply, and plenty do. The connection then completes its handshake and dies as soon as a full-size segment appears, which presents as *"small requests work, large transfers stall"*.

## Change

**One** mangle rule on `chain=forward`, commented `router:mss-clamp`, matching `out-interface-list=WAN` with `new-mss=clamp-to-pmtu`.

### Why there is no matching ingress rule

An earlier revision of this PR added a second rule on `in-interface-list=WAN`, claiming it was needed to cap what the LAN client sends outbound. **That rule was wrong and has been removed.** `clamp-to-pmtu` derives the MSS from the route toward the packet's *destination*. For a SYN-ACK matched on WAN ingress, that destination is the LAN bridge — normally 1500 — so it clamps to 1460 regardless of how narrow the uplink is. It would have looked like it covered the upload direction while doing nothing.

The upload direction is instead covered by the router's own ICMP "fragmentation needed" back to the LAN client. That reply is generated locally, one hop away, so it is rarely the one being filtered.

### Other properties worth review

- **Exact comment matching**, not `comment~"^router:mss-clamp"` — a prefix pattern would also delete an operator's own `router:mss-clamp-custom`.
- **A correct rule is left untouched.** Re-applying does not remove and re-add, so a working gateway is never briefly unclamped.
- **Correctness is judged on every property, and on the rule being enabled.** A comment-only substring test would accept a hand-disabled rule — the exact silent failure the postcondition exists to catch.
- **Failures surface through `configureRouter()`'s postcondition list** rather than being swallowed, matching how `configureWanNotify` reports. This includes the opt-out path, where removal is *confirmed* rather than assumed: reporting a clean apply while the rule is still live is the worst available outcome.
- **Verification runs in both states.** Checking only when clamping is on would let a failed removal pass unnoticed.
- `validate-router` rejects a non-boolean `mssClamp`, since it is compared with `!== false` and a stringy `"false"` from YAML would read as ON.
- `backupRouterConfig` records `mssClamp: false` only when the rule is absent; a read *failure* is left unrecorded, because writing `false` on error would silently strip the clamp on the next apply.

## Scope

**This changes segment size, never rate.** It is a robustness fix for MTU-constrained uplinks, explicitly not a throughput fix.

It came out of investigating a real complaint — a LAN client could not sustain a transfer over an LTE backup — and the clamp turned out **not** to be the cause. That SIM was policed by the carrier to ~63 kbit/s. The missing clamp was a genuine gap found along the way. CLAUDE.md records both, including the diagnostic that separates a policer from an MTU problem: ping during a transfer, because flat RTT with low throughput means an upstream policer, where a shaper would inflate RTT.

## Tests

`npm test`: **102 passed, 0 failed**.

The command tests use a fake device that can throw per command and return realistic terse records, rather than one that always succeeds. Covered: fresh install, an already-correct rule causing no churn, replacement of a rule that was disabled / given a fixed MSS / moved to another chain, failed add, failed read (must not add or remove blind), opt-out, opt-out where the rule survives removal, and opt-out where removal errors. Plus unit coverage of the enabled/property predicate and terse-record parsing.

## Not verified

- Whether the clamp helps on a genuinely MTU-constrained path. The LTE bearer available for testing reports and carries 1500 bytes, so `clamp-to-pmtu` had nothing to clamp. Exercising this needs a PPPoE uplink.
- A full `apply` against live hardware — only the new function was run, to avoid rebuilding firewall and routes on a production gateway.

## Review history

Reviewed adversarially by an independent reviewer, which caught the ingress-rule error described above plus five further issues (non-transactional replacement, swallowed removal errors on opt-out, comment-only verification, over-broad ownership prefix, and tests that restated the implementation). All six are addressed in this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1