### PR TITLE
fix: verify SSIDs actually come up (v6.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [6.2.2] - 2026-08-26 - Verify SSIDs Actually Come Up
+
+An apply could report complete success while an SSID was silently off the air.
+
+Writing an interface's configuration is not the same as the radio accepting it.
+A virtual AP created while its master is being reconfigured in the same pass can
+be rejected, and RouterOS records that only as a comment on the interface:
+
+```
+;;; failed to create interface
+2  BI wifi2-ssid2  wifi2  PartlyWork
+```
+
+The `set` that configured it returns no error, so the tool logged
+`✓ Configured wifi2-ssid2` and moved on. Observed on a Chateau LTE6 running
+RouterOS 7.18.2 with wifi-qcom: one of two configured SSIDs was missing for a
+day behind a fully green apply, and the verification step had no WiFi check at
+all to catch it.
+
+### What changed
+
+Every configured SSID is now read back after it is written.
+
+**Virtual APs** that are not running are disabled and re-enabled — that
+interface alone — and checked again, up to three attempts. The failure behaves
+like a race rather than a hard rejection, and bouncing the virtual AP brings it
+up. One that still will not come up is reported as an unmet requirement, so
+`role: router` applies now fail instead of claiming success. The device's own
+explanation is included when it left one.
+
+**Master radios are never bounced.** The primary SSID on each band is
+configured on the master, so this check runs against masters in normal
+operation, and a master carries every associated client — very possibly
+including whoever is running this tool over that radio.
+
+A master also has entirely benign reasons to read as not-running: a DFS channel
+availability check, a CAP still provisioning, CAPsMAN not finished activating
+it. But so does a bad channel or a driver fault, and treating every one of them
+as healthy would reintroduce this same bug on the primary SSID. So a
+not-yet-running master is **deferred**, then polled until it comes up, on a
+budget that covers a DFS availability check (~60s; up to 90s is allowed). A
+fixed short wait would have condemned every healthy DFS radio — especially
+under CAPsMAN, which applies channel settings immediately beforehand and can
+restart the check. The budget is shared across all deferred radios rather than
+applied to each in turn, so a controller with many inactive CAP radios does not
+multiply the wait, and each poll round reads every outstanding radio so none is
+judged on a stale result. Only a master still down when the budget runs out is
+reported.
+
+Whether an interface is virtual is decided by asking the device for its
+`master-interface`, not by guessing from the name. If that cannot be
+determined, the interface is treated as a master and left alone.
+
+Interfaces whose state cannot be read are reported without pointless retries,
+and a restart that itself fails is reported rather than swallowed.
+
+The check lives in the shared interface-configuration path, so the CAPsMAN
+roles get the retry and reporting too. Those roles have no postcondition
+mechanism, so a dead SSID there is surfaced as a prominent summary at the end
+of the run rather than failing the apply.
+
 ## [6.2.1] - 2026-08-25 - MSS Clamping On WAN Uplinks
 
 The router role installed no TCP MSS clamp at all. On an uplink narrower than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,52 @@ const BAND_TO_INTERFACE = {
 - A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
 - A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
 
+**Writing WiFi Config Is Not The Same As The Radio Accepting It**
+- A virtual AP created while its master is being reconfigured in the same pass can be
+  rejected by the radio. RouterOS reports this ONLY as a comment on the interface
+  (`;;; failed to create interface`) and the configuring `set` returns NO error.
+- This bit us in production: `✓ Configured wifi2-ssid2` was logged while PartlyWork was
+  silently off the air for a day, behind an otherwise green apply.
+- `ensureWifiInterfaceUp()` in `lib/wifi-config.js` reads `/interface get [find name=X]
+  running` after every SSID is written. `running` is the authoritative signal - do not
+  parse the flag column out of `print detail` for this.
+- Recovery is disable-then-enable of THAT VIRTUAL AP ONLY, up to 3 attempts.
+- **NEVER bounce a master radio.** `configureWifiInterface()` is called with the MASTER
+  for the primary SSID on every band, so this code path runs against masters routinely.
+  A master carries every associated client, very possibly including the operator running
+  this tool over that radio. A master also reads not-running for benign reasons (DFS
+  availability check, CAP still provisioning, CAPsMAN not done activating), so it is
+  DEFERRED and then POLLED until it comes up, never bounced. Do NOT just return
+  "healthy" for a not-running master: a bad channel or driver fault reads identically to
+  a DFS check, and calling it fine puts the original bug back on the primary SSID.
+- The deferred check POLLS (default 90s budget, 5s interval); it is not a fixed sleep.
+  DFS CAC takes ~60s and `configureCapInterfacesOnController()` applies channel settings
+  immediately before the recheck, which can RESTART CAC. A short fixed wait reports every
+  healthy DFS radio as dead. A transient read failure mid-poll is not fatal either.
+  Only a master still down when the budget expires is reported.
+- That budget is SHARED across all deferred masters, not per-radio. CAC and provisioning
+  run concurrently on the device, so a per-radio budget would multiply the wait by the
+  fleet size - a controller with 20 dead CAP radios would stall an apply for half an hour.
+- The deadline is measured against a real CLOCK, not against time spent sleeping. Slow or
+  timing-out SSH reads burn real time too; counting only sleeps let the function overrun
+  its budget exactly when reads were slowest. `now` and `sleep` are injectable so tests
+  are deterministic, and a round cap means even a frozen clock cannot spin.
+- A poll ROUND IS ATOMIC: once it starts, every unresolved radio is read in it. Checking
+  the deadline mid-round judges the radios later in map order on their PREVIOUS round's
+  result, so several DFS checks finishing near the deadline would see the first radio
+  pass and the rest falsely reported dead. Check the deadline only BETWEEN rounds; the
+  overrun is bounded by one round's reads.
+- Virtual-vs-master is decided by asking the device for `master-interface`, never by
+  guessing from a `-ssidN` suffix. If that lookup FAILS: do not touch the interface, and
+  do not call it healthy either - report it, or a dead VAP hides behind a failed lookup.
+- A still-dead VIRTUAL AP becomes an unmet requirement so a `role: router` apply FAILS.
+  Reporting success for an SSID nobody can see is the bug being fixed.
+- CAPsMAN has NO postcondition mechanism, so there a dead SSID is surfaced as a loud
+  end-of-run summary instead. Do not claim CAPsMAN fails the apply - it does not.
+- Both CAPsMAN summary calls must sit BEFORE the success banner and in the catch block.
+  Placing one after the try/catch makes it dead code: the try returns and the catch
+  throws. That happened once already and was caught in review.
+
 **Router Role: MSS Clamping (on by default)**
 - ONE mangle rule on `chain=forward`, commented `router:mss-clamp`, matching
   `out-interface-list=WAN` with `new-mss=clamp-to-pmtu`.

--- a/lib/capsman.js
+++ b/lib/capsman.js
@@ -20,6 +20,7 @@ const {
   detectRadioLayout,
   applyBandSettings,
   configureWifiInterface,
+  recheckPendingMasters,
   discoverCapInterfaces
 } = require('./wifi-config');
 
@@ -32,7 +33,38 @@ const {
  *        Each config should have: host, identity, wifi.['2.4GHz'].txPower, wifi.['5GHz'].txPower
  * @returns {boolean} - Success status
  */
+/**
+ * Remember an SSID that never came up, for the summary at the end of a run.
+ *
+ * CAPsMAN has no postcondition mechanism the way the router role does, so the
+ * best available behaviour is to make the failure impossible to miss in the
+ * output rather than to fail the apply.
+ *
+ * @param {string[]} sink - Collected problems
+ * @param {string|null} problem - Result of configureWifiInterface
+ */
+function recordDeadSsid(sink, problem) {
+  if (problem) sink.push(problem);
+}
+
+/**
+ * Print a summary of SSIDs that were configured but never came up.
+ *
+ * @param {string[]} problems - Collected problems
+ */
+function reportDeadSsids(problems) {
+  if (problems.length === 0) return;
+  console.log('\n========================================');
+  console.log(`✗ ${problems.length} SSID(s) were configured but are NOT on the air`);
+  console.log('========================================');
+  problems.forEach(p => console.log(`  - ${p}`));
+  console.log('  Re-run to retry. If it persists, check the radio and channel');
+  console.log('  (a DFS channel can hold an interface down during its availability check).');
+}
+
 async function configureCapInterfacesOnController(config = {}, capDeviceConfigs = []) {
+  const wifiProblems = [];
+  const pendingMasters = [];
   const mt = new MikroTikSSH(
     config.host || '192.168.88.1',
     config.username || 'admin',
@@ -175,9 +207,10 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
       const primarySsid = bandSsids[0];
       console.log(`\nConfiguring ${capInterface.name} with SSID: ${primarySsid.ssid}`);
 
-      await configureWifiInterface(
-        mt, wifiPath, capInterface.name, primarySsid, country, bandSettings
-      );
+      recordDeadSsid(wifiProblems, await configureWifiInterface(
+        mt, wifiPath, capInterface.name, primarySsid, country, bandSettings,
+        { pendingMasters }
+      ));
 
       // Create virtual interfaces for additional SSIDs
       for (let i = 1; i < bandSsids.length; i++) {
@@ -202,9 +235,9 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
         // Small delay for interface registration
         await new Promise(resolve => setTimeout(resolve, 300));
 
-        await configureWifiInterface(
+        recordDeadSsid(wifiProblems, await configureWifiInterface(
           mt, wifiPath, virtualName, additionalSsid, country, bandSettings
-        );
+        ));
       }
 
       // Collect channel settings to apply at the end
@@ -287,9 +320,10 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
       const primarySsid = bandSsids[0];
       console.log(`\nConfiguring ${masterInterface} (${band}) with SSID: ${primarySsid.ssid}`);
 
-      await configureWifiInterface(
-        mt, wifiPath, masterInterface, primarySsid, country, bandSettings
-      );
+      recordDeadSsid(wifiProblems, await configureWifiInterface(
+        mt, wifiPath, masterInterface, primarySsid, country, bandSettings,
+        { pendingMasters }
+      ));
 
       // Create virtual interfaces for additional SSIDs on same band
       for (let i = 1; i < bandSsids.length; i++) {
@@ -313,9 +347,9 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
         // Small delay for interface registration
         await new Promise(resolve => setTimeout(resolve, 300));
 
-        await configureWifiInterface(
+        recordDeadSsid(wifiProblems, await configureWifiInterface(
           mt, wifiPath, virtualName, additionalSsid, country, bandSettings
-        );
+        ));
 
         // Add virtual interface as bridge port with correct PVID
         // Required for wifi-qcom traffic flow (same as configureLocalCapFallback)
@@ -359,6 +393,9 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
       }
     }
 
+    wifiProblems.push(...(await recheckPendingMasters(mt, pendingMasters)));
+    reportDeadSsids(wifiProblems);
+
     console.log('\n========================================');
     console.log('✓ CAP Interface Configuration Complete');
     console.log('========================================\n');
@@ -366,6 +403,8 @@ async function configureCapInterfacesOnController(config = {}, capDeviceConfigs 
     await mt.close();
     return true;
   } catch (error) {
+    // Report what was already found before unwinding, or it is lost.
+    reportDeadSsids(wifiProblems);
     console.error('\n✗ CAP Interface Configuration Error:', error.message);
     await mt.close();
     throw error;
@@ -730,6 +769,8 @@ async function configureCap(config = {}) {
  * @returns {boolean} - Success status
  */
 async function configureLocalCapFallback(capConfig, ssids, country) {
+  const wifiProblems = [];
+  const pendingMasters = [];
   const mt = new MikroTikSSH(
     capConfig.host || '192.168.88.1',
     capConfig.username || 'admin',
@@ -827,9 +868,10 @@ async function configureLocalCapFallback(capConfig, ssids, country) {
       const primarySsid = bandSsids[0];
       console.log(`\nConfiguring ${masterInterface} (${band}) with SSID: ${primarySsid.ssid}`);
 
-      await configureWifiInterface(
-        mt, wifiPath, masterInterface, primarySsid, country, bandSettings
-      );
+      recordDeadSsid(wifiProblems, await configureWifiInterface(
+        mt, wifiPath, masterInterface, primarySsid, country, bandSettings,
+        { pendingMasters }
+      ));
 
       // Create virtual interfaces for additional SSIDs on same band
       for (let i = 1; i < bandSsids.length; i++) {
@@ -853,9 +895,9 @@ async function configureLocalCapFallback(capConfig, ssids, country) {
         // Small delay for interface registration
         await new Promise(resolve => setTimeout(resolve, 300));
 
-        await configureWifiInterface(
+        recordDeadSsid(wifiProblems, await configureWifiInterface(
           mt, wifiPath, virtualName, additionalSsid, country, bandSettings
-        );
+        ));
 
         // Add virtual interface as bridge port with correct PVID
         // This is required for wifi-qcom CAPsMAN "traffic processing on CAP" mode.
@@ -948,11 +990,16 @@ async function configureLocalCapFallback(capConfig, ssids, country) {
       console.log(`  ⚠️  CAP restart warning: ${e.message}`);
     }
 
+    wifiProblems.push(...(await recheckPendingMasters(mt, pendingMasters)));
+    reportDeadSsids(wifiProblems);
+
     console.log(`\n✓ Local WiFi fallback configured for ${identity}`);
 
     await mt.close();
     return true;
   } catch (error) {
+    // Report what was already found before unwinding, or it is lost.
+    reportDeadSsids(wifiProblems);
     console.error(`\n✗ Local WiFi Fallback Error for ${capConfig.host}: ${error.message}`);
     await mt.close();
     return false;  // Non-fatal - continue with other CAPs

--- a/lib/router.js
+++ b/lib/router.js
@@ -31,7 +31,9 @@ const {
 const { getWifiPath, escapeMikroTik } = require('./utils');
 const { q, must, scriptSource, ifaceName, ipv4, cidr, ipRange, duration, integer, ipv4List, IDENTIFIER, HTTP_URL, NOTIFY_TITLE } = require('./routeros-args');
 const { CHANNEL_FREQ_24GHZ, CHANNEL_FREQ_5GHZ } = require('./constants');
-const { detectRadioLayout, detectBandToken, configureWifiInterface } = require('./wifi-config');
+const {
+  detectRadioLayout, detectBandToken, configureWifiInterface, recheckPendingMasters
+} = require('./wifi-config');
 
 const WAN_LIST = 'WAN';
 const LAN_LIST = 'LAN';
@@ -1954,10 +1956,14 @@ async function backupRouterConfig(mt) {
  * @param {Object} config - Device configuration
  */
 async function configureRouterWifi(mt, config) {
+  const problems = [];
+  // Masters are never bounced, so a not-yet-running one is deferred and looked
+  // at again once the rest of the WiFi work has given it time to settle.
+  const pendingMasters = [];
   const ssids = config.ssids || [];
   if (ssids.length === 0) {
     console.log('\nℹ️  No SSIDs configured, radios left untouched');
-    return;
+    return problems;
   }
 
   console.log('\n=== Configuring WiFi ===');
@@ -1967,7 +1973,7 @@ async function configureRouterWifi(mt, config) {
     console.log('⚠️  No supported WiFi package, skipping WiFi');
     console.log('    This tool needs wifi-qcom. Devices on the legacy `wireless`');
     console.log('    package expose /interface wireless instead, which is not supported.');
-    return;
+    return problems;
   }
 
   const wifiPath = getWifiPath(wifiPackage);
@@ -2055,9 +2061,16 @@ async function configureRouterWifi(mt, config) {
         // No named datapath object is created. configureWifiInterface writes
         // the bridge and vlan inline on the interface, so a separate object
         // would never be referenced by anything.
-        await configureWifiInterface(mt, wifiPath, iface, ssidConfig, country, wifiConfig[band] || {});
+        // A configured-but-dead SSID must fail the apply. Writing the config
+        // and moving on is how one of two SSIDs stayed silently off the air.
+        const notUp = await configureWifiInterface(
+          mt, wifiPath, iface, ssidConfig, country, wifiConfig[band] || {},
+          { pendingMasters }
+        );
+        if (notUp) problems.push(notUp);
       } catch (e) {
         console.log(`  ✗ Failed to configure ${iface}: ${e.message}`);
+        problems.push(`SSID "${ssidConfig.ssid}" on ${iface}: ${e.message}`);
       }
     }
   }
@@ -2072,6 +2085,10 @@ async function configureRouterWifi(mt, config) {
       `Could not disable ${bandToInterface[band]}`
     );
   }
+
+  problems.push(...(await recheckPendingMasters(mt, pendingMasters)));
+
+  return problems;
 }
 
 /**
@@ -2215,7 +2232,7 @@ async function configureRouter(config = {}) {
     }
     await configureDhcpServer(mt, lan);
     await configureDns(mt, lan);
-    await configureRouterWifi(mt, config);
+    const wifiProblems = await configureRouterWifi(mt, config);
     await configureSyslog(mt, config);
 
     // Runs after the failover routes exist, because the notifier reads their
@@ -2230,7 +2247,12 @@ async function configureRouter(config = {}) {
       console.log('\n⚠️  Skipping stale-address cleanup because the LAN address was not added.');
     }
 
-    const problems = [...(await verifyRouterState(mt, lan)), ...mssProblems, ...notifyProblems];
+    const problems = [
+      ...(await verifyRouterState(mt, lan)),
+      ...mssProblems,
+      ...wifiProblems,
+      ...notifyProblems
+    ];
     if (problems.length > 0) {
       console.log('\n========================================');
       console.log('✗ Router Configuration INCOMPLETE');

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -139,7 +139,7 @@ async function applyBandSettings(mt, band, interfaceName, bandConfig, wifiPath) 
  * @param {string} country - Country code for WiFi
  * @param {Object} bandSettings - Optional band-specific settings {txPower, channel, width}
  */
-async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, country, bandSettings = {}) {
+async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, country, bandSettings = {}, upOptions = {}) {
   const { ssid, passphrase, vlan, roaming } = ssidConfig;
 
   const useFT = roaming?.fastTransition === true;
@@ -267,6 +267,244 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
     // Logging only - the interface is already configured at this point.
     console.log(`  ✓ Configured ${interfaceName}: SSID="${ssid}"`);
   }
+
+  // Writing the config is not proof the radio accepted it. See the helper.
+  return ensureWifiInterfaceUp(mt, wifiPath, interfaceName, upOptions);
+}
+
+/**
+ * Look again at master radios that were still starting up.
+ *
+ * A master is never bounced, so the only safe way to tell a DFS availability
+ * check from a genuinely dead radio is to wait and look again. Returning
+ * "healthy" for every not-running master would reintroduce the very bug this
+ * change exists to fix, just on the primary SSID instead of a virtual one.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {string[]} names - Interfaces deferred earlier
+ * @param {Object} [options]
+ * @param {number} [options.delayMs=5000] - Settle time before re-checking
+ * @param {Function} [options.sleep] - Injectable delay, for tests
+ * @returns {Promise<string[]>} - Problems for interfaces still not running
+ */
+async function recheckPendingMasters(mt, names, options = {}) {
+  const problems = [];
+  if (!names || names.length === 0) return problems;
+
+  const {
+    // A DFS channel availability check can take ~60s, and applying channel
+    // settings can restart it - CAPsMAN does exactly that immediately before
+    // this runs. A short fixed wait would report every healthy DFS radio as
+    // dead, so poll until they come up instead.
+    timeoutMs = 90000,
+    pollMs = 5000,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    // Injectable so tests are deterministic and do not wait in real time.
+    now = () => Date.now()
+  } = options;
+
+  // ONE deadline for all of them, not one each. CAC and provisioning happen
+  // concurrently on the device, so polling serially would multiply the wait by
+  // the number of radios - a controller with 20 dead CAP radios would otherwise
+  // stall the apply for half an hour. Map also de-duplicates the names.
+  const pending = new Map(names.map(name => [name, null]));
+
+  console.log('\n=== Re-checking radios that were still starting ===');
+  console.log(`  Waiting up to ${Math.round(timeoutMs / 1000)}s in total for ${pending.size} radio(s).`);
+  console.log('  A DFS availability check takes about 60s, and setting a channel can restart it.');
+
+  // Measured against the clock, NOT against time we asked to sleep for. A slow
+  // or timing-out SSH read consumes real time too, and counting only sleeps let
+  // the function run well past its budget exactly when reads were slowest.
+  const started = now();
+  const elapsed = () => now() - started;
+
+  // Belt and braces: even a clock that never advances cannot spin here.
+  const maxRounds = Math.ceil(timeoutMs / Math.max(pollMs, 1)) + 1;
+
+  // A round is an ATOMIC SNAPSHOT: once it starts, every unresolved radio is
+  // read in it. Breaking out mid-round on the deadline would judge the radios
+  // later in the map on their previous round's result - so several DFS checks
+  // finishing near the deadline would see the first radio pass and the rest
+  // falsely reported dead. The deadline is therefore only checked BETWEEN
+  // rounds; the overrun is bounded by one round's worth of reads.
+  for (let round = 1; ; round++) {
+    for (const name of [...pending.keys()]) {
+      try {
+        const out = await mt.exec(`/interface get [find name=${q(name)}] running`);
+        if (/true/i.test(out || '')) {
+          const secs = Math.round(elapsed() / 1000);
+          console.log(`  ✓ ${name} is now running${secs ? ` (after ${secs}s)` : ''}`);
+          pending.delete(name);
+        } else {
+          pending.set(name, null);
+        }
+      } catch (e) {
+        // Keep polling: a transient read failure mid-CAC should not condemn a
+        // radio that is about to come up. Reported only if it never resolves.
+        pending.set(name, e);
+      }
+
+    }
+
+    if (pending.size === 0) break;
+    if (elapsed() >= timeoutMs || round >= maxRounds) break;
+
+    // Never overshoot the shared budget.
+    const step = Math.min(pollMs, timeoutMs - elapsed());
+    if (step <= 0) break;
+    await sleep(step);
+  }
+
+  const waitedSecs = Math.round(elapsed() / 1000);
+  for (const [name, readError] of pending) {
+    const problem = readError
+      ? `${name} could not be re-checked: ${readError.message}`
+      : `${name} is configured but still not running after ${waitedSecs}s - ` +
+        'its SSID is not on the air';
+    console.log(`  ✗ ${problem}`);
+    problems.push(problem);
+  }
+
+  return problems;
+}
+
+/**
+ * Confirm an SSID actually made it onto the air, retrying if it did not.
+ *
+ * Writing the configuration is not the same as the radio accepting it. A
+ * virtual AP created while its master is being reconfigured in the same pass
+ * can be rejected by the radio, and RouterOS records that only as a comment on
+ * the interface:
+ *
+ *   ;;; failed to create interface
+ *   2  BI wifi2-ssid2  wifi2  PartlyWork
+ *
+ * The `set` that configured it returns no error, so an apply that only writes
+ * config reports success while the SSID is silently dead. Observed on a
+ * Chateau LTE6 (RouterOS 7.18.2, wifi-qcom): the second SSID was absent for a
+ * day behind a fully green apply.
+ *
+ * The failure appears to be a race rather than a hard rejection - disabling and
+ * re-enabling just that interface brings it up, without touching the master or
+ * disturbing associated clients. So: read back, and retry the interface alone.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {string} wifiPath - Base wifi path for this package
+ * @param {string} interfaceName - Interface to check
+ * @param {Object} [options]
+ * @param {number} [options.attempts=3] - Total attempts, including the first check
+ * @param {number} [options.delayMs=3000] - Settle time after enabling
+ * @param {Function} [options.sleep] - Injectable delay, for tests
+ * @returns {Promise<string|null>} - A problem description, or null when up
+ */
+async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) {
+  const {
+    attempts = 3,
+    delayMs = 3000,
+    pendingMasters = null,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+  } = options;
+
+  // `running` is the authoritative signal and is unambiguous, unlike parsing
+  // the flag column out of `print detail`.
+  const isUp = async () => {
+    const out = await mt.exec(`/interface get [find name=${q(interfaceName)}] running`);
+    return /true/i.test(out || '');
+  };
+
+  // Only a VIRTUAL AP may be bounced. This function is called for the primary
+  // SSID on each band too, and that is the MASTER radio - which carries every
+  // associated client, very possibly including the operator running this tool
+  // over that same radio. A master can also be legitimately not-running for a
+  // while: DFS channel availability check, a CAP still provisioning, CAPsMAN
+  // not finished activating it. Bouncing it would turn a benign wait into an
+  // outage, and reporting it as a failure would be a false alarm.
+  let isVirtual = false;
+  let classified = false;
+  let classifyError = null;
+  try {
+    const master = await mt.exec(
+      `${wifiPath} get [find name=${q(interfaceName)}] master-interface`
+    );
+    isVirtual = Boolean(master && master.trim() && !/^\s*$/.test(master));
+    classified = true;
+  } catch (e) {
+    // Cannot tell what this is. Never toggle it - but do not call it healthy
+    // either, or a dead VAP could hide behind a failed lookup.
+    isVirtual = false;
+    classifyError = e;
+  }
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      if (await isUp()) {
+        if (attempt > 1) console.log(`  ✓ ${interfaceName} came up on attempt ${attempt}`);
+        return null;
+      }
+    } catch (e) {
+      lastError = e;
+      // Cannot read state; there is nothing useful to retry against.
+      const problem = `${interfaceName} could not be read back after configuration: ${e.message}`;
+      console.log(`  ✗ ${problem}`);
+      return problem;
+    }
+
+    if (!isVirtual) {
+      // Never touch a master. But "not running" is not proof of health either:
+      // a bad channel, a radio rejection or a driver fault reads exactly like a
+      // DFS availability check. So defer it and look again once the rest of the
+      // apply has given it time to settle.
+      if (!classified) {
+        const problem = `${interfaceName} could not be identified as master or virtual` +
+          `${classifyError ? `: ${classifyError.message}` : ''} - left untouched, and it is not running`;
+        console.log(`  ✗ ${problem}`);
+        return problem;
+      }
+      console.log(`  ⚠️  ${interfaceName} is not running yet - it is a master radio, so it is left alone.`);
+      console.log('     A DFS availability check or a CAP still provisioning looks like this.');
+      if (pendingMasters) {
+        if (!pendingMasters.includes(interfaceName)) pendingMasters.push(interfaceName);
+        console.log('     Will re-check before the run finishes.');
+        return null;
+      }
+      const problem = `${interfaceName} is configured but not running - its SSID is not on the air`;
+      console.log(`  ✗ ${problem}`);
+      return problem;
+    }
+
+    if (attempt === attempts) break;
+
+    console.log(`  ⚠️  ${interfaceName} is not running, retrying (${attempt}/${attempts - 1})`);
+    try {
+      // This interface only. Never the master.
+      await mt.exec(`${wifiPath} set [find name=${q(interfaceName)}] disabled=yes`);
+      await sleep(500);
+      await mt.exec(`${wifiPath} set [find name=${q(interfaceName)}] disabled=no`);
+      await sleep(delayMs);
+    } catch (e) {
+      lastError = e;
+      const problem = `${interfaceName} could not be restarted: ${e.message}`;
+      console.log(`  ✗ ${problem}`);
+      return problem;
+    }
+  }
+
+  // Surface the device's own explanation when it left one.
+  let reason = '';
+  try {
+    const detail = await mt.exec(`${wifiPath} print detail without-paging where name=${q(interfaceName)}`);
+    const comment = (detail || '').match(/;;; *(.+)/);
+    if (comment) reason = ` (device says: ${comment[1].trim()})`;
+  } catch (e) { /* the problem below stands on its own */ }
+
+  const problem = `${interfaceName} is configured but not running${reason}` +
+    (lastError ? ` - last error: ${lastError.message}` : '');
+  // Logged here as well as returned, because not every caller consumes the
+  // return value. An SSID nobody can see must never be silent.
+  console.log(`  ✗ ${problem}`);
+  return problem;
 }
 
 /**
@@ -649,6 +887,8 @@ module.exports = {
   detectRadioLayout,
   applyBandSettings,
   configureWifiInterface,
+  ensureWifiInterfaceUp,
+  recheckPendingMasters,
   getSwappedRadioCaps,
   getRadioBandMapping,
   renameCapInterfacesToMatchBand,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -17,6 +17,7 @@ const {
   parseTerseRecord
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
+const { ensureWifiInterfaceUp, recheckPendingMasters } = require('../lib/wifi-config');
 const { validateRouterConfig } = require('../lib/validate-router');
 
 let passed = 0, failed = 0;
@@ -954,6 +955,273 @@ test('omitting mssClamp is valid and leaves it on', () => {
   const offErrProblems = await configureMssClamp(offErrors, false);
   test('opting out reports a removal error instead of swallowing it', () => {
     assert.ok(/could not remove/i.test(offErrProblems.join('; ')), offErrProblems.join('; '));
+  });
+
+  console.log('\n=== WiFi interface comes up (VAP creation retry) ===');
+
+  // A VAP created while its master is being reconfigured can be rejected by the
+  // radio. RouterOS reports that ONLY as a comment on the interface - the `set`
+  // that configured it returns no error - so an apply that just writes config
+  // reports success while the SSID is silently off the air.
+  const FAILED_DETAIL = ' 2   BI ;;; failed to create interface\n'
+    + '        name="wifi2-ssid2" master-interface=wifi2 configuration.ssid="PartlyWork"';
+
+  // running=false until the Nth read, then true. `master` decides whether the
+  // device presents this interface as a virtual AP or as a master radio.
+  const wifiDevice = (upFromRead, opts = {}) => {
+    let reads = 0;
+    const sent = [];
+    return {
+      sent,
+      exec: async cmd => {
+        sent.push(cmd);
+        if (cmd.includes('master-interface')) {
+          if (opts.masterLookupThrows) throw new Error('no such item');
+          return opts.isMaster ? '' : 'wifi2';
+        }
+        if (cmd.includes('] running')) {
+          reads++;
+          if (opts.readThrows) throw new Error('no such item');
+          return reads >= upFromRead ? 'true' : 'false';
+        }
+        if (cmd.includes('disabled=') && opts.toggleThrows) throw new Error('permission denied');
+        if (cmd.includes('print detail')) return FAILED_DETAIL;
+        return '';
+      }
+    };
+  };
+  const noSleep = { sleep: async () => {}, delayMs: 0 };
+  const toggles = d => d.sent.filter(c => c.includes('disabled='));
+
+  const upFirstTry = wifiDevice(1);
+  const upFirstProblem = await ensureWifiInterfaceUp(upFirstTry, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  test('an interface that is already running is left alone', () => {
+    assert.strictEqual(upFirstProblem, null);
+    assert.strictEqual(toggles(upFirstTry).length, 0, 'must not bounce a working interface');
+  });
+
+  const upAfterRetry = wifiDevice(2);
+  const retryProblem = await ensureWifiInterfaceUp(upAfterRetry, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  test('a virtual AP that failed to create is retried and comes up', () => {
+    assert.strictEqual(retryProblem, null, `expected recovery, got: ${retryProblem}`);
+    assert.deepStrictEqual(
+      toggles(upAfterRetry).map(c => /disabled=(\w+)/.exec(c)[1]), ['yes', 'no'],
+      'recovery is disable-then-enable'
+    );
+  });
+
+  // THE SAFETY PROPERTY. The primary SSID on each band is configured on the
+  // MASTER radio, so this function is called with a master in normal operation.
+  // The master carries every associated client - very possibly including the
+  // operator running this tool over that radio. It must never be bounced.
+  // A master also has benign reasons to read not-running: DFS channel
+  // availability check, a CAP still provisioning, CAPsMAN not done activating.
+  const masterDown = wifiDevice(99, { isMaster: true });
+  const masterProblem = await ensureWifiInterfaceUp(masterDown, '/interface/wifi', 'wifi2', noSleep);
+  test('a MASTER radio that is not running is NEVER bounced', () => {
+    assert.strictEqual(toggles(masterDown).length, 0,
+      `must not touch a master radio, sent: ${JSON.stringify(toggles(masterDown))}`);
+  });
+  test('a not-running master is DEFERRED, never silently called healthy', async () => {
+    // Returning "fine" for every not-running master would reintroduce this very
+    // bug on the primary SSID. A bad channel or a driver fault reads exactly
+    // like a DFS check, so the only safe answer is to look again later.
+    const pendingMasters = [];
+    const deferred = wifiDevice(99, { isMaster: true });
+    const problem = await ensureWifiInterfaceUp(deferred, '/interface/wifi', 'wifi2',
+      { ...noSleep, pendingMasters });
+    assert.strictEqual(problem, null, 'deferred, so not an immediate failure');
+    assert.deepStrictEqual(pendingMasters, ['wifi2'], 'must be queued for re-check');
+    assert.strictEqual(toggles(deferred).length, 0, 'still must not bounce it');
+  });
+
+  test('a not-running master with nowhere to defer is reported, not passed', async () => {
+    const orphan = wifiDevice(99, { isMaster: true });
+    const problem = await ensureWifiInterfaceUp(orphan, '/interface/wifi', 'wifi2', noSleep);
+    assert.ok(problem, 'must not report a dead master as healthy');
+    assert.ok(/not running/i.test(problem), problem);
+    assert.strictEqual(toggles(orphan).length, 0, 'still must not bounce it');
+  });
+
+  const neverUp = wifiDevice(99);
+  const neverProblem = await ensureWifiInterfaceUp(neverUp, '/interface/wifi', 'wifi2-ssid2',
+    { ...noSleep, attempts: 3 });
+  test('a virtual AP that never comes up is reported, not passed', () => {
+    assert.ok(neverProblem, 'a dead SSID must produce a problem');
+    assert.ok(/not running/i.test(neverProblem), neverProblem);
+    // The device's own explanation is worth surfacing to whoever reads the log.
+    assert.ok(/failed to create interface/.test(neverProblem),
+      `expected the device's reason, got: ${neverProblem}`);
+  });
+  test('retries are bounded', () => {
+    const bounces = neverUp.sent.filter(c => c.includes('disabled=yes')).length;
+    assert.strictEqual(bounces, 2, `3 attempts means 2 retries, got ${bounces}`);
+  });
+
+  const unreadable = wifiDevice(1, { readThrows: true });
+  const unreadableProblem = await ensureWifiInterfaceUp(unreadable, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  test('an unreadable interface is reported without blind retries', () => {
+    assert.ok(unreadableProblem, 'must report');
+    assert.ok(/could not be read back/i.test(unreadableProblem), unreadableProblem);
+    assert.strictEqual(toggles(unreadable).length, 0,
+      'no point bouncing an interface whose state cannot be read');
+  });
+
+  const stuck = wifiDevice(99, { toggleThrows: true });
+  const stuckProblem = await ensureWifiInterfaceUp(stuck, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  test('a failed restart is reported rather than swallowed', () => {
+    assert.ok(/could not be restarted/i.test(stuckProblem), stuckProblem);
+  });
+
+  console.log('\n=== Deferred master re-check ===');
+
+  const recheckDevice = replies => {
+    const sent = [];
+    let i = 0;
+    return {
+      sent,
+      exec: async cmd => {
+        sent.push(cmd);
+        // Past the end of the script, keep answering with the last value.
+        const reply = replies[Math.min(i++, replies.length - 1)];
+        if (reply instanceof Error) throw reply;
+        return reply;
+      }
+    };
+  };
+  // A fake clock that advances only when the code sleeps, so the suite is
+  // deterministic and never waits out a real DFS check. Fresh per call.
+  const fastPoll = (extra = {}) => {
+    let t = 0;
+    return {
+      timeoutMs: 20000,
+      pollMs: 5000,
+      now: () => t,
+      sleep: async ms => { t += ms; },
+      ...extra
+    };
+  };
+
+  test('a master that came up during the apply is not reported', async () => {
+    const d = recheckDevice(['true']);
+    const problems = await recheckPendingMasters(d, ['wifi2'], fastPoll());
+    assert.deepStrictEqual(problems, [], 'a DFS check that finished is not a failure');
+  });
+
+  test('a DFS master that comes up mid-poll is not reported', async () => {
+    // CAC finishing after the first look is the common healthy case; a fixed
+    // short wait would have condemned it.
+    const d = recheckDevice(['false', 'false', 'true']);
+    const problems = await recheckPendingMasters(d, ['wifi2'], fastPoll());
+    assert.deepStrictEqual(problems, [], 'must keep polling, not give up at the first look');
+    assert.ok(d.sent.length >= 3, `expected repeated polling, got ${d.sent.length} reads`);
+  });
+
+  test('polling is bounded by the timeout', async () => {
+    const d = recheckDevice(['false']);
+    await recheckPendingMasters(d, ['wifi2'], fastPoll());
+    // 20s budget at 5s steps = 5 reads (t=0,5,10,15,20), never unbounded.
+    assert.ok(d.sent.length <= 6, `polling must be bounded, got ${d.sent.length} reads`);
+  });
+
+  test('a master still down at the end IS reported', async () => {
+    const d = recheckDevice(['false']);
+    const problems = await recheckPendingMasters(d, ['wifi2'], fastPoll());
+    assert.strictEqual(problems.length, 1, `expected a problem, got: ${problems}`);
+    assert.ok(/not on the air/i.test(problems[0]), problems[0]);
+  });
+
+  test('a transient read failure does not condemn a radio that recovers', async () => {
+    const d = recheckDevice([new Error('timeout'), 'true']);
+    assert.deepStrictEqual(await recheckPendingMasters(d, ['wifi2'], fastPoll()), [],
+      'one failed read mid-CAC must not be fatal');
+  });
+
+  test('a master that can never be re-checked is reported', async () => {
+    const d = recheckDevice([new Error('timeout')]);
+    const problems = await recheckPendingMasters(d, ['wifi2'], fastPoll());
+    assert.ok(/could not be re-checked/i.test(problems.join('; ')), problems.join('; '));
+  });
+
+  test('many down radios share ONE deadline, not one each', async () => {
+    // A controller with a fleet of dead CAP radios must not stall the apply for
+    // 90s per radio. CAC runs concurrently on the device anyway.
+    const d = recheckDevice(['false']);
+    const problems = await recheckPendingMasters(d, ['wifi1', 'wifi2', 'wifi3', 'wifi4'], fastPoll());
+    assert.strictEqual(problems.length, 4, 'every dead radio is still reported');
+    // 20s budget / 5s steps = 5 rounds x 4 radios = 20 reads. Per-radio budgets
+    // would be ~4x that.
+    assert.ok(d.sent.length <= 24, `expected one shared deadline, got ${d.sent.length} reads`);
+  });
+
+  test('a repeated master name is only checked once', async () => {
+    const d = recheckDevice(['false']);
+    const problems = await recheckPendingMasters(d, ['wifi2', 'wifi2'], fastPoll());
+    assert.strictEqual(problems.length, 1, 'duplicates must collapse');
+  });
+
+  test('SLOW READS consume the budget, not just sleeps', async () => {
+    // Counting only requested sleep time let this run far past its budget
+    // precisely when reads were slowest - the failure mode the timeout exists
+    // to bound. Here each read burns 8s of clock and nothing ever sleeps.
+    let t = 0;
+    const d = {
+      sent: [],
+      exec: async cmd => { d.sent.push(cmd); t += 8000; return 'false'; }
+    };
+    const problems = await recheckPendingMasters(d, ['wifi2'], {
+      timeoutMs: 20000, pollMs: 5000, now: () => t, sleep: async () => {}
+    });
+    assert.strictEqual(problems.length, 1, 'still reported');
+    // 20s budget at 8s per read = 3 reads. Without a wall clock this never ends.
+    assert.ok(d.sent.length <= 4, `slow reads must count, got ${d.sent.length} reads`);
+  });
+
+  test('a clock that never advances cannot spin forever', async () => {
+    // Belt and braces: the round cap bounds it even if a caller passes a
+    // no-op sleep and a frozen clock.
+    const d = recheckDevice(['false']);
+    const problems = await recheckPendingMasters(d, ['wifi2'], {
+      timeoutMs: 20000, pollMs: 5000, now: () => 0, sleep: async () => {}
+    });
+    assert.strictEqual(problems.length, 1);
+    assert.ok(d.sent.length <= 6, `round cap must bound it, got ${d.sent.length} reads`);
+  });
+
+  test('a round is atomic: every radio is read in the round that starts', async () => {
+    // Radios later in map order must not be judged on a stale previous-round
+    // result just because the deadline passed mid-round. Several DFS checks
+    // completing near the deadline would otherwise be reported dead.
+    let t = 0;
+    const upAt = { wifi1: 2, wifi2: 2, wifi3: 2, wifi4: 2 };
+    const reads = {};
+    const d = {
+      sent: [],
+      exec: async cmd => {
+        d.sent.push(cmd);
+        const name = /name="([^"]+)"/.exec(cmd)[1];
+        reads[name] = (reads[name] || 0) + 1;
+        t += 3000;                       // each read burns clock
+        return reads[name] >= upAt[name] ? 'true' : 'false';
+      }
+    };
+    const problems = await recheckPendingMasters(d, ['wifi1', 'wifi2', 'wifi3', 'wifi4'], {
+      timeoutMs: 20000, pollMs: 1000, now: () => t, sleep: async ms => { t += ms; }
+    });
+    // Round 2 runs t=13->25 and the 20s deadline passes partway through it.
+    // Cutting the round short there would leave wifi4 unresolved and reported
+    // dead even though it comes up in the very same round.
+    assert.deepStrictEqual(problems, [],
+      `all four came up in round 2; none should be reported: ${problems}`);
+    for (const name of Object.keys(upAt)) {
+      assert.ok(reads[name] >= 2, `${name} only got ${reads[name]} reads - round was cut short`);
+    }
+  });
+
+  test('nothing deferred means no device round trip', async () => {
+    const d = recheckDevice([]);
+    assert.deepStrictEqual(await recheckPendingMasters(d, [], fastPoll()), []);
+    assert.strictEqual(d.sent.length, 0, 'must not talk to the device for an empty list');
   });
 
   console.log('\n=== Host resolution (lockout guard) ===');


### PR DESCRIPTION
## The production bug

Applying a two-SSID config to a live Chateau LTE6 (RouterOS 7.18.2, wifi-qcom) reported complete success:

```
✓ Created virtual interface wifi2-ssid2
✓ Configured wifi2-ssid2: SSID="PartlyWork", untagged
...
✓✓✓ Router Configuration Complete! ✓✓✓
```

Only one SSID was actually on the air. The device had marked the virtual AP:

```
;;; failed to create interface
2  BI wifi2-ssid2  wifi2  PartlyWork
```

`B` bound, `I` inactive. The `set` that configured it returned no error, so the tool wrote the config, logged success and moved on. `verifyRouterState()` had no WiFi postcondition at all. **The SSID was dead for a day behind a fully green apply.** Disabling and re-enabling only that virtual interface brought it up.

## The change

Every configured SSID is read back after it is written, via `/interface get [find name=X] running` — authoritative, rather than parsing the flag column out of `print detail`.

**Virtual APs** that are not running are disabled and re-enabled — that interface alone — and re-checked, up to three attempts. One that still will not come up becomes an unmet requirement, so a `role: router` apply now fails instead of claiming success. The device's own explanation is included when it left one.

**Master radios are never bounced.** This is the safety property that matters: `configureWifiInterface()` is called with the master for the primary SSID on every band, so this path runs against masters routinely, and a master carries every associated client — very possibly including the operator running this tool over that radio.

But a not-running master is not assumed healthy either, or the same bug simply moves to the primary SSID. It is **deferred**, then polled until it comes up against a shared 90-second budget that covers a DFS availability check. Whether an interface is virtual is decided by asking the device for `master-interface`, never by guessing from a `-ssidN` suffix; if that lookup fails, the interface is left untouched *and* reported.

The check lives in the shared interface path, so the CAPsMAN roles get the retry and reporting too. CAPsMAN has no postcondition mechanism, so a dead SSID there is surfaced as a prominent end-of-run summary rather than failing the apply — stated plainly rather than overclaimed.

## Tests

`npm test`: **129 passed, 0 failed.**

Covers: already-running left alone; a failed VAP retried and recovering; a master never bounced; a master deferred rather than passed; an unidentifiable interface left alone and reported; bounded retries; unreadable interfaces reported without blind retries; a failed restart reported; deferred masters recovering mid-poll; slow reads consuming the budget; a frozen clock bounded by the round cap; a shared deadline across a fleet; and an atomic round where the deadline falls mid-round.

## Review history

Seven rounds of independent adversarial review, ending APPROVED with zero findings. It caught, in order:

1. **`ensureWifiInterfaceUp` would bounce master radios** — my "never touches the master" claim was false, since masters are passed in for every primary SSID. The test that "proved" it was tautological.
2. All six CAPsMAN call sites discarded the result, so the fix did not apply there despite the changelog saying it did.
3. The master-safe version returned "healthy" for any not-running master, reintroducing the original bug on the primary SSID.
4. Both CAPsMAN summary calls were **dead code** — placed after a `try` that returns and a `catch` that throws.
5. A fixed 5s settle wait would report every healthy DFS radio as dead, made worse by CAPsMAN applying channel settings immediately beforehand.
6. A per-radio 90s budget could stall a controller apply for half an hour.
7. Counting only sleep time let the budget overrun exactly when reads were slowest.
8. Breaking mid-round on the deadline judged later radios on stale results — a regression introduced by the fix for 7.

Items 1, 3, 4 and 8 were defects introduced while fixing earlier rounds, which is the argument for iterating rather than stopping at the first pass.

## Not verified

The original failure is a race and I could not reproduce it on demand, so the retry path is proven by unit tests rather than by observing a live VAP fail and recover. The manual disable/enable that fixed the production device is the evidence that the recovery action itself works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1