### PR TITLE
fix: RouterOS get needs :put — 6.2.2 verification never worked (v6.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [6.2.3] - 2026-08-26 - Fix: `get` Needs `:put` (6.2.2 Did Not Work)
+
+**6.2.2 did not work.** The SSID verification it added never functioned on real
+hardware, and it made applies fail spuriously. Upgrade straight to 6.2.3.
+
+A bare `/interface get [find name=X] running` prints **nothing** over an SSH
+exec. RouterOS returns the value to an interactive console, not to stdout. It
+has to be wrapped:
+
+```
+:put [/interface/get [find name="wifi2"] running]
+```
+
+6.2.2 sent the bare form for both of its queries. Every read came back as an
+empty string, so:
+
+- every interface looked not-running, and
+- every `master-interface` lookup looked empty, so every interface was
+  classified as a master radio.
+
+On a live Chateau LTE6 that produced an apply which reported a perfectly
+healthy master as `not running after 90s`, classified the virtual AP as a
+master, and therefore **never ran the retry the feature exists for**. The
+apply then failed with two unmet requirements while the WiFi was fine.
+
+### What changed
+
+Both queries are wrapped in `:put`. The command forms were verified against
+live hardware before release this time, rather than only against a test double.
+
+Two regression tests: one pins the query form, and one scans this module for
+any `exec()` sending a bare `get [find ...]`, so the whole class of bug is
+caught rather than the single instance.
+
+### Why the tests missed it
+
+The fake device returned canned values for whatever it was asked. It never
+checked that the command was one RouterOS would actually answer. A mock that
+answers a question the real device ignores will pass every time.
+
 ## [6.2.2] - 2026-08-26 - Verify SSIDs Actually Come Up
 
 An apply could report complete success while an SSID was silently off the air.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,19 @@ const BAND_TO_INTERFACE = {
 - A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
 - A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
 
+**RouterOS `get` MUST Be Wrapped In `:put` (learned the hard way in 6.2.2)**
+- `/interface get [find name=X] running` sent over an SSH exec prints NOTHING. RouterOS
+  returns the value to an interactive console, not to stdout. Always:
+  `:put [/interface/get [find name=X] running]`
+- 6.2.2 shipped the bare form. Every read came back empty, so every interface looked
+  not-running and every classification lookup looked empty. The apply reported a healthy
+  master as dead and never ran the VAP retry it existed to run.
+- Unit tests did NOT catch this: the fake answered whatever it was asked. A mock that
+  answers a question the real device ignores passes every time. When adding a NEW device
+  query, run it against real hardware, and assert the command FORM in a test.
+- `test/router.test.js` scans lib/wifi-config.js for `exec()` calls sending a bare
+  `get [find ...]`. Keep that guard.
+
 **Writing WiFi Config Is Not The Same As The Radio Accepting It**
 - A virtual AP created while its master is being reconfigured in the same pass can be
   rejected by the radio. RouterOS reports this ONLY as a comment on the interface

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -273,6 +273,27 @@ async function configureWifiInterface(mt, wifiPath, interfaceName, ssidConfig, c
 }
 
 /**
+ * Ask the device whether an interface is running.
+ *
+ * MUST be wrapped in `:put`. A bare `/interface get ... running` prints NOTHING
+ * over an SSH exec - RouterOS returns the value to an interactive console, not
+ * to stdout. Without the wrapper every read comes back as an empty string, so
+ * every interface looks not-running and every lookup looks empty.
+ *
+ * That is not hypothetical: v6.2.2 shipped the bare form. On a live Chateau it
+ * reported a perfectly healthy master as "not running after 90s" and classified
+ * a virtual AP as a master, so the retry this whole feature exists for never
+ * fired. Unit tests missed it because the fake returned canned values and never
+ * checked that the command was one RouterOS actually answers.
+ *
+ * @param {string} name - Interface name
+ * @returns {string} - Command whose stdout is "true" or "false"
+ */
+function runningQuery(name) {
+  return `:put [/interface/get [find name=${q(name)}] running]`;
+}
+
+/**
  * Look again at master radios that were still starting up.
  *
  * A master is never bounced, so the only safe way to tell a DFS availability
@@ -331,7 +352,7 @@ async function recheckPendingMasters(mt, names, options = {}) {
   for (let round = 1; ; round++) {
     for (const name of [...pending.keys()]) {
       try {
-        const out = await mt.exec(`/interface get [find name=${q(name)}] running`);
+        const out = await mt.exec(runningQuery(name));
         if (/true/i.test(out || '')) {
           const secs = Math.round(elapsed() / 1000);
           console.log(`  ✓ ${name} is now running${secs ? ` (after ${secs}s)` : ''}`);
@@ -409,7 +430,7 @@ async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) 
   // `running` is the authoritative signal and is unambiguous, unlike parsing
   // the flag column out of `print detail`.
   const isUp = async () => {
-    const out = await mt.exec(`/interface get [find name=${q(interfaceName)}] running`);
+    const out = await mt.exec(runningQuery(interfaceName));
     return /true/i.test(out || '');
   };
 
@@ -425,7 +446,7 @@ async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) 
   let classifyError = null;
   try {
     const master = await mt.exec(
-      `${wifiPath} get [find name=${q(interfaceName)}] master-interface`
+      `:put [${wifiPath}/get [find name=${q(interfaceName)}] master-interface]`
     );
     isVirtual = Boolean(master && master.trim() && !/^\s*$/.test(master));
     classified = true;
@@ -889,6 +910,7 @@ module.exports = {
   configureWifiInterface,
   ensureWifiInterfaceUp,
   recheckPendingMasters,
+  runningQuery,
   getSwappedRadioCaps,
   getRadioBandMapping,
   renameCapInterfacesToMatchBand,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -17,7 +17,9 @@ const {
   parseTerseRecord
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
-const { ensureWifiInterfaceUp, recheckPendingMasters } = require('../lib/wifi-config');
+const {
+  ensureWifiInterfaceUp, recheckPendingMasters, runningQuery
+} = require('../lib/wifi-config');
 const { validateRouterConfig } = require('../lib/validate-router');
 
 let passed = 0, failed = 0;
@@ -957,6 +959,32 @@ test('omitting mssClamp is valid and leaves it on', () => {
     assert.ok(/could not remove/i.test(offErrProblems.join('; ')), offErrProblems.join('; '));
   });
 
+  console.log('\n=== RouterOS query FORM (get needs :put) ===');
+
+  // v6.2.2 shipped `/interface get [find name=X] running` with no `:put`. Over
+  // an SSH exec that prints NOTHING - RouterOS returns the value to an
+  // interactive console, not to stdout. Every read came back empty, so every
+  // interface looked not-running and every classification lookup looked empty.
+  // On live hardware it reported a healthy master as dead and treated a virtual
+  // AP as a master, so the retry never fired. The old tests could not catch it:
+  // the fake returned canned values and never checked the command form.
+  test('the running query is wrapped in :put', () => {
+    const cmd = runningQuery('wifi2-ssid2');
+    assert.ok(cmd.startsWith(':put ['), `a bare get prints nothing over SSH: ${cmd}`);
+    assert.ok(cmd.endsWith(']'), cmd);
+    assert.ok(cmd.includes('running'), cmd);
+    assert.ok(cmd.includes('name="wifi2-ssid2"'), cmd);
+  });
+
+  test('every device query this module sends is :put-wrapped', () => {
+    // Guards the whole class of bug, not just the one instance.
+    const src = require('fs').readFileSync(require.resolve('../lib/wifi-config'), 'utf8');
+    const bare = src.split('\n').filter(line =>
+      /exec\(/.test(line) && /\bget \[find/.test(line) && !/:put \[/.test(line));
+    assert.deepStrictEqual(bare, [],
+      `these send a bare get and will read back empty:\n${bare.join('\n')}`);
+  });
+
   console.log('\n=== WiFi interface comes up (VAP creation retry) ===');
 
   // A VAP created while its master is being reconfigured can be rejected by the
@@ -979,7 +1007,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
           if (opts.masterLookupThrows) throw new Error('no such item');
           return opts.isMaster ? '' : 'wifi2';
         }
-        if (cmd.includes('] running')) {
+        if (cmd.includes('running')) {
           reads++;
           if (opts.readThrows) throw new Error('no such item');
           return reads >= upFromRead ? 'true' : 'false';


### PR DESCRIPTION
## 6.2.2 does not work

The SSID verification added in #22 never functioned on real hardware, and it made applies fail spuriously. This restores it and proves it against a live device.

A bare `get` prints **nothing** over an SSH exec — RouterOS returns the value to an interactive console, not to stdout:

```
/interface/wifi get [find name="wifi2-ssid2"] master-interface       -> (nothing)
:put [/interface/wifi/get [find name="wifi2-ssid2"] master-interface] -> wifi2
```

6.2.2 sent the bare form for both of its queries, so every read came back as an empty string. Consequently every interface looked not-running, and every `master-interface` lookup looked empty so every interface was classified as a master radio.

On a live Chateau LTE6 the 6.2.2 apply produced:

```
✓ Configured wifi2: SSID="PartlyPrimary", untagged
⚠️  wifi2 is not running yet - it is a master radio, so it is left alone.
✓ Configured wifi2-ssid2: SSID="PartlyWork", untagged
⚠️  wifi2-ssid2 is not running yet - it is a master radio, so it is left alone.
...
✗ wifi2 is configured but still not running after 90s
✗ wifi2-ssid2 is configured but still not running after 90s
✗ Router Configuration INCOMPLETE
```

`wifi2` was running the entire time, `wifi2-ssid2` is a virtual AP and not a master, and **the retry the feature exists for never ran**. The VAP creation race did recur during that apply, so the SSID went down and had to be recovered by hand — exactly the outcome 6.2.2 was written to prevent.

## The fix

Both queries wrapped in `:put`, behind a named `runningQuery()` helper carrying the explanation.

## Verified on live hardware

Driven against the real device before opening this PR, with every command logged:

```
SCENARIO 1 - healthy MASTER (wifi2)
  > :put [/interface/wifi/get [find name="wifi2"] master-interface]   < ""      -> master
  > :put [/interface/get [find name="wifi2"] running]                 < "true"
  toggles issued: 0        returned: null

SCENARIO 2 - VAP forced not-running (wifi2-ssid2)
  > :put [/interface/wifi/get [find name="wifi2-ssid2"] master-interface] < "wifi2" -> virtual
  > :put [/interface/get [find name="wifi2-ssid2"] running]               < "false"
  > /interface/wifi set [find name="wifi2-ssid2"] disabled=yes
  > /interface/wifi set [find name="wifi2-ssid2"] disabled=no
  > :put [/interface/get [find name="wifi2-ssid2"] running]               < "true"
  ✓ wifi2-ssid2 came up on attempt 2
  toggles issued: 2        returned: null   (3.9s)
```

Master correctly identified and never touched; VAP correctly identified; real `running` values read; retry fires; interface recovers.

**Not proven:** the deferral path for a master that is *down*. Exercising it means taking the master radio offline, which is the operator's own link to the device. That branch remains unit-test-only.

## Why the tests missed it, and what now guards it

The fake device answered whatever it was asked. **A mock that answers a question the real device ignores passes every time.** Seven rounds of adversarial review on #22 also missed it — the review asked whether the `master-interface` check matched RouterOS behaviour, and we reasoned about semantics while neither of us checked the command *form* against hardware.

Two regression tests:

1. Pins the query form — `runningQuery()` must be `:put`-wrapped.
2. Scans `lib/wifi-config.js` for any `exec()` sending a bare `get [find ...]`, so the whole class of bug is guarded rather than this one instance.

`npm test`: **131 passed, 0 failed.**

## Upgrading

Skip 6.2.2. It is worse than 6.2.1: it fails applies on healthy hardware while providing none of the verification it advertises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1