### PR TITLE
Management cannot reach the WAN, and a realistic VAP settle budget (v6.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,8 +183,10 @@ A second review round found three more, all fixed:
   bound the LAN range. The LAN is not exempt: if an unresolved DHCP, LTE or
   PPPoE uplink later takes an address inside it, binding to that network admits
   the WAN exactly as an allow entry would. A PPPoE uplink's address also lands
-  on `pppoe-<name>` rather than the ethernet the config names, so that
-  interface is now derived — without it the uplink looks addressless forever.
+  on `pppoe-<name>` rather than the ethernet the config names, so the client
+  interface REPLACES the parent in the watch set — on a normal PPPoE setup the
+  parent never carries an address, so keeping both would leave the router
+  permanently unhardenable.
 
 One finding was accepted rather than fixed: a polling round that has already
 started runs to completion even past its deadline, so a round over many

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,18 @@ A second review round found three more, all fixed:
   parent never carries an address, so keeping both would leave the router
   permanently unhardenable.
 
+### Known limitation
+
+**Every configured uplink must hold an address at the moment of the apply**, or
+nothing is bound. A standby link that is unplugged, or an LTE backup with no
+signal, is a perfectly normal multi-WAN state and will defer the hardening
+until it comes up. The apply says so explicitly and names the uplink.
+
+There is deliberately no override. Ignoring an uplink whose address is unknown
+is precisely how management ends up reachable from the WAN: an unresolved DHCP
+or LTE link can take an address inside an allowed range moments after the apply
+finishes. The firewall rule keeps the uplinks closed in the meantime.
+
 One finding was accepted rather than fixed: a polling round that has already
 started runs to completion even past its deadline, so a round over many
 unresponsive radios can overrun by up to 30s each. Cutting the round short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,22 @@ a remote router. Review caught it, and these are the corrections:
   answer used to mean "virtual AP". Getting that wrong means bouncing a *master*
   radio and cutting every client, possibly including the operator's own link.
 
+A second review round found three more, all fixed:
+
+- **A service is added to the rollback set the moment its write lands**, not
+  after it verifies. Adding it on success meant the one service whose write
+  landed but whose read-back failed was the one service never rolled back.
+- **Rollback writes are verified too.** "Accepted but did no work" is the exact
+  failure that made immediate verification necessary going in, and it is no
+  less possible on the way back out. A rollback that does not read back correct
+  reports `URGENT` with console instructions.
+- **Unknown uplink state now binds nothing at all**, where it previously still
+  bound the LAN range. The LAN is not exempt: if an unresolved DHCP, LTE or
+  PPPoE uplink later takes an address inside it, binding to that network admits
+  the WAN exactly as an allow entry would. A PPPoE uplink's address also lands
+  on `pppoe-<name>` rather than the ethernet the config names, so that
+  interface is now derived — without it the uplink looks addressless forever.
+
 One finding was accepted rather than fixed: a polling round that has already
 started runs to completion even past its deadline, so a round over many
 unresponsive radios can overrun by up to 30s each. Cutting the round short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,142 @@
 # Changelog
 
+## [6.2.5] - 2026-08-28 - Management Cannot Reach the WAN, and a Realistic VAP Settle Budget
+
+Two fixes. The first closes a real exposure in the `role: router` path; the
+second stops that same role failing applies on healthy hardware.
+
+### 1. `/ip service` is bound to the LAN, not left listening on any address
+
+On a live router configured by this tool, every management service listened on
+`address=""` — any source:
+
+```
+0   name="telnet" port=23   address=""
+2   name="www" port=80      address=""
+3   name="ssh" port=22      address=""
+6   name="winbox" port=8291 address=""
+```
+
+The only thing keeping that off the uplinks was a single firewall rule,
+`router:input-drop-wan`. That rule works — 34,937 packets dropped on the test
+device, and no logins from the WAN-side subnet — but it is one object. Delete
+it, reorder it, or add a permissive input rule above it, and the entire
+management surface is on the internet behind whatever password the device has.
+
+Now every entry in `/ip service` is bound to the LAN network derived from
+`lan.address`. The check moves into RouterOS's own accept path, where no
+firewall edit can reach it. The firewall rule stays; the two layers fail
+independently.
+
+Also closed, because they bypass both of those layers:
+
+- **telnet and ftp are disabled.** Cleartext, and this tool drives devices over
+  SSH. Opt out with `lan.management.cleartext: true` — they stay LAN-bound.
+- **MAC-telnet, MAC-winbox and neighbor discovery are scoped to the `LAN`
+  interface list.** These run over layer 2. They ignore `/ip service address=`
+  *and* the IP firewall input chain, so an attacker on the WAN broadcast domain
+  reaches them without needing an IP at all. RouterOS defconf sets them
+  correctly; nothing enforced or verified it.
+- **Disabled services are bound too**, so re-enabling one by hand later cannot
+  reopen the WAN.
+
+RoMON is reported when enabled, not switched off. It is layer 2 as well, this
+tool does not own it, and it is off from the factory.
+
+**No user config can undo this.** The escape hatch, `lan.management.allow`,
+takes additional source ranges, and its grammar cannot express a WAN address:
+every entry must be non-globally-routable (RFC1918, CGNAT, link-local,
+loopback), which is checked on the entry's *network* so `10.0.0.1/1` cannot
+smuggle in half the internet. Private is not sufficient on its own — the test
+device's own `ether1` sits on `192.168.4.0/22` behind another router — so every
+entry is checked again at apply time against the addresses actually on the
+uplinks, and one that covers a live uplink address is dropped and reported.
+
+### The lockout guard, which outranks all of the above
+
+This tool connects over SSH. Restricting `/ip service` while the operator is
+reaching the device from somewhere the restriction excludes locks them out of a
+remote gateway permanently. That is far worse than the exposure being fixed, so
+the device is asked who is connected to it right now:
+
+```
+/user active print terse
+0 when=2026-08-28 12:14:40 name=admin address=192.168.80.199 via=ssh group=full
+```
+
+Unless **every** active session is covered by the allow list, nothing is
+restricted. The device's own view is used rather than this process's idea of its
+source address, because a jump host, a NAT gateway or a VPN concentrator all
+rewrite it on the way. Not being able to tell counts as not covered — an
+unreadable session list, or an empty one, both mean "restrict nothing".
+
+Skipping is a loud warning, not a failed apply, matching what the firewall step
+already does when it cannot verify the LAN list. The WAN drop rule still stands
+in that case.
+
+Two more consequences worth knowing:
+
+- Changing `lan.address` leaves the operator on the old subnet, so the first
+  apply skips the restriction and the second one — made over the new address —
+  lands it. This is the same two-run shape the LAN address migration already
+  has.
+- SSH is bound **last**, after every other service has proved the command shape.
+  If it still reads back excluding the current session, the restriction is
+  cleared again automatically: RouterOS applies `address=` to new connections
+  only, so a wrong value does not drop the live session and the lockout would
+  not surface until the next connect. The apply still fails.
+
+Every write is verified by reading it back, and this turned out to matter more
+than expected: **RouterOS reports an invalid argument on stdout, not stderr**,
+so the SSH client resolves rather than throwing. "The command did not error" is
+not evidence that it did anything.
+
+`lan.management` round-trips through backup, but only when the restriction is
+demonstrably in place. A device whose `ssh` service still listens on any address
+has simply never been hardened, and recording `cleartext: true` off the back of
+that would let a backup/restore cycle silently carry "leave telnet on" forward
+for ever.
+
+### 2. The virtual-AP settle budget is a poll, not a 6-second guess
+
+6.2.3 waited a flat 3 seconds after toggling a virtual AP and gave up after two
+toggles — about 6 seconds of settle. On the live Chateau that produced a **false
+negative**: the apply exhausted the budget, reported
+`wifi2-ssid2 is configured but not running`, exited INCOMPLETE, and the
+interface came up on its own moments later. A second apply on the same device
+recovered inside the budget and passed. So it was marginal, and it failed in the
+direction that breaks any automation gating on the exit code.
+
+After the toggle the tool now polls `running` until the interface comes up or a
+60-second budget expires, instead of sleeping a fixed moment and asking once.
+Polling costs nothing on a healthy interface — it returns on the first read —
+so the budget is only spent on a genuine failure, which is what makes a generous
+one nearly free. The budget is **shared** across the retries rather than granted
+per retry, so raising `attempts` divides it instead of multiplying the wait.
+
+The honest failure is kept: when the budget genuinely expires the problem is
+still reported, with the device's own explanation. And the master-radio safety
+property is unchanged — a master is never toggled and never enters the settle
+poll, because it carries every associated client, very possibly including the
+operator running this tool over that radio.
+
+`recheckPendingMasters()` already did exactly this polling, correctly: one
+shared deadline, a wall clock rather than accumulated sleep time, bounded and
+atomic rounds. Both callers now share that one implementation
+(`pollUntilRunning`) rather than keeping a second copy to drift.
+
+### Verified on hardware
+
+Every new device command was run against a live Chateau LTE6 (RouterOS 7.18.2)
+before being relied on, and the tests assert command *form*, not just behaviour:
+
+- `address=` rejects any value with a host bit set, so the LAN network is masked
+  before it is sent.
+- `:put [... get address]` renders a multi-entry list **semicolon**-separated
+  while `print terse` renders the same list **comma**-separated. Both are parsed.
+- `/tool mac-server print terse` is a syntax error; those settings must be read
+  with `:put [... get ...]`.
+
 ## [6.2.4] - 2026-08-28 - Failed Commands Now Actually Fail
 
 `MikroTikSSH.exec()` resolved whenever stderr was empty. RouterOS prints its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,46 @@ before being relied on, and the tests assert command *form*, not just behaviour:
 - `/tool mac-server print terse` is a syntax error; those settings must be read
   with `:put [... get ...]`.
 
+### Hardened after review
+
+The first draft of this change could have permanently locked an operator out of
+a remote router. Review caught it, and these are the corrections:
+
+- **Every write is verified immediately, and a failure rolls the whole run
+  back.** Previously services were bound one after another and verified only at
+  the end. A failure partway through left a device half-restricted - and if it
+  landed before `ssh`, every alternative recovery path was bound while the
+  lifeline was not. The prior value of each service is recorded first, so a
+  rollback restores what was actually there rather than blanking it.
+- **The ssh self-heal now confirms the clear took.** It cleared the restriction
+  and assumed success. Since 6.2.4 a failed command throws, but a command can
+  also be accepted and not do what was asked, and this is the one place where
+  being wrong means never reaching the device again. It reads back, and says
+  `URGENT` with console instructions if the clear did not land.
+- **A session we cannot parse now blocks the restriction.** The code claimed
+  "not being able to tell counts as not covered" and then silently skipped
+  unparseable sessions, so a readable session elsewhere let the guard pass. An
+  IPv6 peer or an address-less record now stops the whole thing.
+- **A LAN that contains a live uplink address binds nothing.** It used to bind
+  anyway and report it. That installs an allow-list which *admits the WAN* while
+  reporting that management was locked to the LAN - claiming a protection that
+  is not being provided, which is worse than not providing it.
+- **An allow entry is dropped when any uplink has no address yet.** A private
+  range proves nothing: this hardware's own WAN is `192.168.4.0/22`. The only
+  real check is against the address actually on the uplink, and a DHCP or LTE
+  uplink can acquire one inside an allowed range moments after the apply
+  finishes.
+- **Interface classification requires an interface-name shape.** Any non-empty
+  answer used to mean "virtual AP". Getting that wrong means bouncing a *master*
+  radio and cutting every client, possibly including the operator's own link.
+
+One finding was accepted rather than fixed: a polling round that has already
+started runs to completion even past its deadline, so a round over many
+unresponsive radios can overrun by up to 30s each. Cutting the round short
+would judge the remaining radios on a stale result and report healthy DFS
+radios as dead. A slow answer is a better failure than a wrong one, and it only
+occurs when the device has already stopped responding.
+
 ## [6.2.4] - 2026-08-28 - Failed Commands Now Actually Fail
 
 `MikroTikSSH.exec()` resolved whenever stderr was empty. RouterOS prints its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,140 @@ const BAND_TO_INTERFACE = {
 - Firewall order is deliberate: accept established, drop invalid, accept ICMP, accept `in-interface-list=LAN`, and only THEN drop `in-interface-list=!LAN`. The drop rule is skipped entirely if the LAN list cannot be verified to contain `bridge`.
 - Fasttrack is OFF by default (`lan.fasttrack: true` to enable). Fasttracked flows skip connection tracking, which slows how fast stale sessions clear after a failover.
 
+**Router Role: The Management Plane Cannot Reach The WAN (v6.2.4)**
+- Before this, every `/ip service` entry listened on `address=""` (any source). The ONLY
+  thing keeping admin off the uplinks was one firewall rule, `router:input-drop-wan`.
+  It worked - 34,937 packets dropped on the live device, zero WAN-side logins - but it
+  is a single object. Delete it, reorder it, or add a permissive input rule above it and
+  the whole management surface is exposed behind whatever password the device has.
+- `configureManagementServices()` in `lib/router.js` binds EVERY `/ip service` entry to
+  `networkOf(lan.address)`, so RouterOS's own accept path refuses an off-LAN connection.
+  The firewall rule STAYS. Two layers, independent failure modes; do not remove either.
+- Disabled services are bound too (`www-ssl` ships disabled). Binding only the enabled
+  ones would leave a one-command path back to an exposed management plane.
+- `telnet` and `ftp` are disabled: cleartext, and this tool drives devices over SSH.
+  `lan.management.cleartext: true` keeps them, still LAN-bound.
+- LAYER 2 BYPASSES ALL OF THAT. MAC-telnet and MAC-winbox run over ethernet frames -
+  no IP, so neither `/ip service address=` nor the firewall input chain applies. An
+  attacker on the WAN broadcast domain reaches them without an address. `/tool mac-server`,
+  `/tool mac-server mac-winbox` and `/ip neighbor discovery-settings` are set to the `LAN`
+  interface list and VERIFIED. RouterOS defconf already sets them; nothing enforced it.
+  Gated on `lanListVerified` for the same reason the drop rule is: pointing MAC-winbox at
+  a list without the bridge removes the recovery path that exists for this kind of mistake.
+- RoMON is layer 2 too. It is REPORTED when enabled, not switched off: this tool does not
+  own it and it is off from the factory. `/tool romon port add interface=<wan> forbid=yes`
+  is the fix. Not implemented because device-mode blocked live verification on the test
+  device, and an unverified device command is how v6.2.2 shipped broken.
+
+**The Escape Hatch Cannot Express A WAN Address (the design tension, resolved)**
+- Requirement was "no WAN admin access under ANY config a user writes", but a router
+  managed across a VPN needs SOME way to widen access. Both hold only if the hatch's
+  GRAMMAR cannot name a WAN source.
+- `lan.management.allow` entries must be non-globally-routable: RFC1918, CGNAT
+  (100.64.0.0/10, where Tailscale lives), link-local, loopback. See `PRIVATE_SCOPES`.
+- Checked on the entry's NETWORK, not its address. `10.0.0.1/1` looks private and masks
+  to `0.0.0.0/1` - half the internet. Testing the address would have waved it through.
+- PRIVATE IS NOT SUFFICIENT ON ITS OWN. The test device's own `ether1` sits on
+  192.168.4.0/22 behind another router, and CGNAT is a real WAN range on some ISPs. So
+  every entry is ALSO compared at apply time against the addresses actually on the
+  uplinks (`readWanAddresses()`), and one covering a live uplink address is dropped and
+  reported. A DHCP/LTE address is not in the config; only a runtime check can see it.
+- If `lan.address` ITSELF covers an uplink address (LAN 192.168.0.0/16, WAN 192.168.4.24),
+  the entry is KEPT and reported. Dropping it would leave an empty list, which means no
+  restriction at all - strictly worse. The firewall covers the overlap.
+
+**Router Role: The Lockout Guard On /ip service (outranks the exposure it fixes)**
+- This tool connects over SSH. Restricting `/ip service` while the operator is reaching
+  the device from somewhere the restriction excludes locks them out of a REMOTE gateway
+  permanently. That is far worse than the exposure being closed.
+- Ask the DEVICE who is connected: `/user active print terse` ->
+  `0 when=... name=admin address=192.168.80.199 via=ssh group=full`. Unless EVERY active
+  session is covered by the allow list, restrict nothing.
+- Use the device's view, never this process's idea of its own source address. A jump
+  host, a NAT gateway or a VPN concentrator all rewrite it on the way; only the router
+  knows what it will compare `address=` against. (`conn.sock.localAddress` was considered
+  and rejected for exactly that reason.)
+- "Cannot tell" == "not covered". An unreadable session list, or an EMPTY one, both mean
+  restrict nothing. This session must appear in that list, so empty means the command or
+  the parse is broken, not that nobody is connected.
+- Any uncovered session blocks it, not just ours. There is no reliable way to tell which
+  active session belongs to this process.
+- Skipping is a WARNING, not an unmet requirement. `configureRouterFirewall()` already
+  skips its drop rule the same way when it cannot verify the LAN list. Failing an
+  otherwise-good apply because a SAFETY guard fired is its own kind of breakage, and the
+  firewall rule still stands.
+- Changing `lan.address` therefore skips the restriction on run 1 (operator is on the old
+  subnet) and lands it on run 2. Same two-run shape as the LAN address migration.
+- SSH is bound LAST, after every other service proved the command shape. If it reads back
+  EXCLUDING the current session, it is cleared again automatically - RouterOS applies
+  `address=` to new connections only, so a wrong value does not drop the live session and
+  the lockout would not surface until the next connect. The apply still FAILS. If the
+  clear also fails, the problem is prefixed `URGENT:`.
+- A wrong ssh value that still COVERS the session is reported but NOT cleared. Reopening
+  the management plane to answer a mismatch that is not a lockout is the wrong trade.
+
+**RouterOS Reports Invalid Arguments On STDOUT, So mt.exec Resolves (v6.2.4)**
+- Verified live: `/ip service set [find name="ftp"] address="192.168.80.1/24"` returns
+  `invalid value for argument address: ...` as normal output. `lib/ssh-client.js` rejects
+  only when STDERR has data, so the promise RESOLVES and the try/catch never fires.
+- Consequence: "the command did not throw" is NOT evidence it did anything. Every write in
+  `configureManagementServices()` is verified by reading it back. Assume this for any new
+  device write.
+- `address=` also rejects any value with a host bit set ("value of address must have all
+  host bits zero"), which is why the LAN network is masked with `networkOf()` before it is
+  sent, and why user-supplied `allow` entries are masked rather than passed through.
+
+**RouterOS Renders One Address List Two Different Ways**
+- `print terse` -> `address=192.168.80.0/24,100.64.0.0/10` (COMMA, unquoted when set,
+  but `address=""` when empty in `print detail`).
+- `:put [/ip service get [find name="ssh"] address]` -> `192.168.80.0/24;100.64.0.0/10`
+  (SEMICOLON - `:put` renders an array). Both reach `parseAddressList()`. Handling only
+  one reads a two-entry list as one malformed entry, so verification passes or fails at
+  random.
+- `/tool mac-server print terse` is a SYNTAX ERROR. Those settings must be read with
+  `:put [/tool mac-server get allowed-interface-list]`.
+
+**Backup Records The Restriction Only When It Is Demonstrably In Place**
+- `backupRouterConfig()` reads `lan.management` only when the `ssh` service actually has
+  an address list. A device whose ssh still listens on any address has simply never been
+  hardened.
+- Recording `cleartext: true` off the back of an unhardened device would let a
+  backup/restore cycle silently carry "leave telnet on" forward for ever. Same shape as
+  the `mssClamp: false` rule: never record a default that would UNDO hardening.
+- The LAN network is filtered out of `allow` - `lan.address` already implies it.
+
+**VAP Settle Budget Is A Poll, Not A Fixed Wait (v6.2.4, fixing 6.2.3)**
+- 6.2.3 waited a flat `delayMs=3000` after toggling a virtual AP, `attempts=3`, so about
+  6s of settle. TOO SHORT, and it fails in the wrong direction.
+- Production evidence, same live Chateau, two real applies:
+  - Apply A: retried twice, exhausted the budget, reported `wifi2-ssid2 is configured but
+    not running`, apply exited INCOMPLETE - and the interface came up moments later. A
+    FALSE NEGATIVE breaks any automation gating on the exit code.
+  - Apply B: `retrying (1/2)` then recovered inside the budget and passed. So: marginal.
+  - Separately measured: a VAP toggled from a DISABLED state recovers in 3.9s. Recovery
+    after a FRESH create is evidently slower than that.
+- Now: toggle once, then POLL `running` until it comes up or a 60s budget expires.
+- Why 60s. Polling costs NOTHING on a healthy interface - it returns on the first read -
+  so the budget is only spent on a genuine failure. That makes a generous budget nearly
+  free, which is why it is not tuned tightly to the observed ~6s. It stays under the 90s
+  the master re-check allows for a DFS availability check.
+- The budget is SHARED across retries (`timeoutMs / (attempts - 1)` each), not granted
+  per retry. Raising `attempts` divides it instead of multiplying the wait.
+- Attempt 1 is a plain read, never a poll: the common case is already-up and must not pay
+  a poll cycle. Verified by asserting the fake clock never advances for a healthy VAP.
+- The honest failure is KEPT. An expired budget still reports the problem, still with the
+  device's own `;;; failed to create interface` explanation. Do not "fix" this into
+  waiting longer and then claiming success - that was the bug 6.2.2 existed to fix.
+- The master-radio property is UNCHANGED: a master is never toggled and never enters the
+  settle poll. It carries every associated client, very possibly including the operator.
+- `pollUntilRunning()` in `lib/wifi-config.js` is now shared by `ensureWifiInterfaceUp()`
+  and `recheckPendingMasters()`. Do not write a third copy. Its awkward properties are
+  all load-bearing: ONE shared deadline for all names (a controller with 20 dead radios
+  would otherwise stall for timeout x 20); time measured against the WALL CLOCK, not
+  accumulated sleep (a slow SSH read burns real time, and counting only sleeps ran past
+  the budget exactly when reads were slowest); ATOMIC rounds (breaking out mid-round
+  judges later names on a stale previous-round result); and a read failure is NOT fatal.
+
 **LTE Notes (Chateau LTE6 / EG06-A)**
 - `/interface lte monitor lte1 once` showing `status: connected` only means the modem attached to the tower. It does NOT mean the data session has an IP.
 - If there is no address on lte1 and no default route, the APN is wrong. Check `/ip address print where interface=lte1`.
@@ -705,6 +839,12 @@ run().catch(e => console.error(e.message));
 - `/system/resource print` - System info
 
 ## Testing
+
+**`test()` in test/router.test.js DOES NOT AWAIT its callback.** An `async` test body is
+counted as a pass whatever it asserts, and a failed assertion surfaces only as an
+unhandled rejection. Do the `await` OUTSIDE the `test()` call and assert on the result
+synchronously, which is what most of the file already does.
+
 
 Backup existing configuration:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,20 @@ const BAND_TO_INTERFACE = {
 - A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
 - A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
 
+**Management Binding Requires Every Uplink To Have An Address**
+- `configureManagementServices()` binds NOTHING - not even the LAN range - unless every
+  uplink that must resolve holds an address. An unresolved DHCP/LTE/PPPoE uplink can take
+  one inside `lanNetwork` or an allow entry moments later, which would make the binding
+  admit the WAN.
+- Consequence: a standby uplink that is unplugged, or an LTE backup with no signal, defers
+  hardening indefinitely. That is intended. Do NOT add an override that skips unresolved
+  uplinks - it re-opens exactly the hole this exists to close.
+- TWO sets, deliberately: `mustResolve` (must have an address before any range is trusted)
+  and `checkAddresses` (any address present must be checked for overlap). A PPPoE PARENT is
+  in the second only: it normally has no address, so requiring one makes the feature
+  permanently inert, but it CAN carry one (DHCP to reach the modem) and that address is on
+  the WAN side. Conflating the two sets broke it in both directions during review.
+
 **RouterOS Reports Errors On STDOUT With A NON-ZERO EXIT (fixed in 6.2.4)**
 - A rejected command writes its error to **stdout**, leaves **stderr empty**, and exits
   **non-zero**. Before 6.2.4 `exec()` only rejected on stderr, so it resolved and returned

--- a/lib/router.js
+++ b/lib/router.js
@@ -1530,40 +1530,60 @@ function managementAllowList(lan = {}) {
  * @returns {Promise<string[]>} - CIDR addresses found on uplink interfaces
  */
 async function readWanAddresses(mt, wans = []) {
-  const uplinks = new Set(wans.map(w => w.interface).filter(Boolean));
-
-  // The WAN list is authoritative for interfaces the config does not name
-  // directly - a pppoe-out client, say, whose parent ether is what is
-  // configured but whose address lands on the client interface.
-  // A pppoe uplink's address lands on the CLIENT interface, not the ethernet
-  // the config names, so the client is what must be watched. The parent is
-  // REPLACED rather than joined by it: on a normal pppoe setup the parent
-  // never carries an address at all, so leaving it in the set would keep
-  // `unresolved` permanently non-empty and management could never be hardened
-  // on a healthy pppoe router.
+  // TWO different questions, so two different sets. Conflating them is how the
+  // pppoe parent ended up either blocking hardening forever (when it had to
+  // resolve) or going unchecked (when it was dropped):
+  //
+  //   mustResolve   - interfaces whose address we REQUIRE before trusting any
+  //                   range. An uplink with no address yet can take one later,
+  //                   inside a range we just allowed.
+  //   checkAddresses - interfaces whose addresses must be CHECKED for overlap
+  //                   if they have any. A pppoe parent belongs here but not
+  //                   above: it legitimately has no address on a normal setup,
+  //                   yet it CAN carry one (DHCP for reaching the modem), and
+  //                   that address is on the WAN side just the same.
+  const mustResolve = new Set();
+  const checkAddresses = new Set();
   const pppoeParents = new Set();
+
   for (const wan of wans) {
-    if (!wan || wan.type !== 'pppoe') continue;
-    if (wan.name) uplinks.add(`pppoe-${wan.name}`);
-    if (wan.interface) pppoeParents.add(wan.interface);
+    if (!wan) continue;
+    if (wan.type === 'pppoe') {
+      if (wan.name) {
+        mustResolve.add(`pppoe-${wan.name}`);
+        checkAddresses.add(`pppoe-${wan.name}`);
+      }
+      // The parent is checked but not required.
+      if (wan.interface) {
+        checkAddresses.add(wan.interface);
+        pppoeParents.add(wan.interface);
+      }
+      continue;
+    }
+    if (wan.interface) {
+      mustResolve.add(wan.interface);
+      checkAddresses.add(wan.interface);
+    }
   }
 
   let discoveryFailed = null;
   try {
     const members = await mt.exec(`/interface list member print terse where list=${WAN_LIST}`);
     for (const record of terseRecords(members)) {
-      const iface = parseTerseRecord(record).interface;
-      if (iface) uplinks.add(iface.replace(/"/g, ''));
+      const raw = parseTerseRecord(record).interface;
+      if (!raw) continue;
+      const iface = raw.replace(/"/g, '');
+      checkAddresses.add(iface);
+      // An interface discovered from the list, whose type we do not know, is
+      // required to resolve - unless it is a pppoe parent, which we do know
+      // about and which legitimately has none.
+      if (!pppoeParents.has(iface)) mustResolve.add(iface);
     }
   } catch (e) {
     // Silently falling back to the configured interfaces means an uplink this
     // tool does not know about is never checked at all.
     discoveryFailed = e.message;
   }
-
-  // The parent is in the WAN interface list too, so it has to be removed after
-  // discovery as well as before it.
-  for (const parent of pppoeParents) uplinks.delete(parent);
 
   const found = [];
   const seen = new Set();
@@ -1572,7 +1592,7 @@ async function readWanAddresses(mt, wans = []) {
     for (const record of terseRecords(out)) {
       const fields = parseTerseRecord(record);
       const iface = (fields['actual-interface'] || fields.interface || '').replace(/"/g, '');
-      if (!uplinks.has(iface)) continue;
+      if (!checkAddresses.has(iface)) continue;
       if (fields.address && parseCidr(fields.address)) {
         found.push(fields.address);
         seen.add(iface);
@@ -1581,14 +1601,12 @@ async function readWanAddresses(mt, wans = []) {
   } catch (e) {
     // An unreadable answer is not "no addresses". Saying so is the difference
     // between failing closed and silently deciding the uplinks are harmless.
-    return { addresses: [], unresolved: [...uplinks], readFailed: e.message, discoveryFailed };
+    return { addresses: [], unresolved: [...mustResolve], readFailed: e.message, discoveryFailed };
   }
 
-  // An uplink with no address YET is the dangerous case: DHCP or LTE can hand
-  // it one a moment later, inside a range we just decided was safe to allow.
   return {
     addresses: found,
-    unresolved: [...uplinks].filter(i => !seen.has(i)),
+    unresolved: [...mustResolve].filter(i => !seen.has(i)),
     readFailed: null,
     discoveryFailed
   };
@@ -1702,10 +1720,15 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
     console.log(`⚠️  Nothing was bound: ${why},`);
     console.log('    so no range can be proven not to cover an uplink. A DHCP or LTE uplink');
     console.log('    can take an address inside one a moment after this finishes.');
+    console.log('    KNOWN LIMITATION: every configured uplink must hold an address at the');
+    console.log('    moment of the apply. A standby link that is unplugged, or an LTE backup');
+    console.log('    with no signal, is a normal multi-WAN state and will block this until it');
+    console.log('    comes up. There is deliberately no override: ignoring an uplink whose');
+    console.log('    address is unknown is exactly how management would end up on the WAN.');
     console.log('    The router:input-drop-wan firewall rule still keeps the uplinks closed.');
     problems.push(
-      `Management was left unrestricted because ${why}. Re-apply once every uplink has ` +
-      'an address.'
+      `Management was left unrestricted because ${why}. Bring that uplink up and apply ` +
+      'again; every configured uplink must hold an address during the apply.'
     );
     return problems;
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -1535,13 +1535,25 @@ async function readWanAddresses(mt, wans = []) {
   // The WAN list is authoritative for interfaces the config does not name
   // directly - a pppoe-out client, say, whose parent ether is what is
   // configured but whose address lands on the client interface.
+  // A pppoe uplink's address lands on the CLIENT interface, not the ethernet
+  // the config names. Without this the address is invisible and the uplink
+  // looks addressless forever.
+  for (const wan of wans) {
+    if (wan && wan.type === 'pppoe' && wan.name) uplinks.add(`pppoe-${wan.name}`);
+  }
+
+  let discoveryFailed = null;
   try {
     const members = await mt.exec(`/interface list member print terse where list=${WAN_LIST}`);
     for (const record of terseRecords(members)) {
       const iface = parseTerseRecord(record).interface;
       if (iface) uplinks.add(iface.replace(/"/g, ''));
     }
-  } catch (e) { /* fall back to the configured interfaces */ }
+  } catch (e) {
+    // Silently falling back to the configured interfaces means an uplink this
+    // tool does not know about is never checked at all.
+    discoveryFailed = e.message;
+  }
 
   const found = [];
   const seen = new Set();
@@ -1559,12 +1571,17 @@ async function readWanAddresses(mt, wans = []) {
   } catch (e) {
     // An unreadable answer is not "no addresses". Saying so is the difference
     // between failing closed and silently deciding the uplinks are harmless.
-    return { addresses: [], unresolved: [...uplinks], readFailed: e.message };
+    return { addresses: [], unresolved: [...uplinks], readFailed: e.message, discoveryFailed };
   }
 
   // An uplink with no address YET is the dangerous case: DHCP or LTE can hand
   // it one a moment later, inside a range we just decided was safe to allow.
-  return { addresses: found, unresolved: [...uplinks].filter(i => !seen.has(i)), readFailed: null };
+  return {
+    addresses: found,
+    unresolved: [...uplinks].filter(i => !seen.has(i)),
+    readFailed: null,
+    discoveryFailed
+  };
 }
 
 /**
@@ -1653,29 +1670,38 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
 
   // A private-scope allow list is not proof on its own - a double-NAT uplink is
   // RFC1918 too. Compare against what is actually on the uplinks right now.
-  const { addresses: wanAddresses, unresolved, readFailed } = await readWanAddresses(mt, wans);
+  const {
+    addresses: wanAddresses, unresolved, readFailed, discoveryFailed
+  } = await readWanAddresses(mt, wans);
 
   // Fail CLOSED on an uplink whose address we cannot see. A private range is
   // not proof of anything - this device's own WAN is 192.168.4.0/22 - so the
   // only check that can catch a clash is against the address actually on the
   // uplink. No address means no check, and a DHCP or LTE uplink can acquire one
   // inside an allowed range moments after we finish.
-  const uplinkStateUnknown = Boolean(readFailed) || unresolved.length > 0;
-  if (uplinkStateUnknown && allow.some(entry => entry !== lanNetwork)) {
-    const why = readFailed
-      ? `the uplink addresses could not be read (${readFailed})`
-      : `${unresolved.join(', ')} has no address yet`;
-    console.log(`⚠️  Dropping every lan.management.allow entry: ${why},`);
-    console.log('    so none of them can be proven not to cover an uplink.');
+  // Bind NOTHING while any uplink's address is unknown - not even the LAN range.
+  // The LAN is not special here: if an unresolved DHCP, LTE or PPPoE uplink
+  // later takes an address inside lanNetwork, binding to that network admits
+  // the WAN exactly as an allow entry would. No range has been PROVEN disjoint
+  // from every uplink, so none of them can be trusted yet.
+  const uplinkStateUnknown = Boolean(readFailed) || Boolean(discoveryFailed) || unresolved.length > 0;
+  if (uplinkStateUnknown) {
+    const why = readFailed ? `the uplink addresses could not be read (${readFailed})`
+      : discoveryFailed ? `the WAN interface list could not be read (${discoveryFailed})`
+        : `${unresolved.join(', ')} has no address yet`;
+    console.log(`⚠️  Nothing was bound: ${why},`);
+    console.log('    so no range can be proven not to cover an uplink. A DHCP or LTE uplink');
+    console.log('    can take an address inside one a moment after this finishes.');
+    console.log('    The router:input-drop-wan firewall rule still keeps the uplinks closed.');
     problems.push(
-      `lan.management.allow was ignored because ${why}. Re-apply once every uplink has ` +
-      'an address, or remove the entry.'
+      `Management was left unrestricted because ${why}. Re-apply once every uplink has ` +
+      'an address.'
     );
+    return problems;
   }
 
   const kept = [];
   for (const entry of allow) {
-    if (entry !== lanNetwork && uplinkStateUnknown) continue;
     const clash = wanAddresses.find(addr => cidrContains(addr.split('/')[0], entry));
     if (!clash) {
       kept.push(entry);
@@ -1780,12 +1806,33 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
     if (applied.length === 0) return;
     console.log(`⚠️  ${why}`);
     console.log(`    Rolling back ${applied.length} service(s) to how they were.`);
-    for (const name of applied.reverse()) {
+    // Copy rather than reverse() in place: `applied` is still read for
+    // reporting after this runs.
+    for (const name of [...applied].reverse()) {
+      const want = prior.get(name) || '';
       try {
-        await mt.exec(`/ip service set [find name=${q(name)}] address=${q(prior.get(name))}`);
+        await mt.exec(`/ip service set [find name=${q(name)}] address=${q(want)}`);
       } catch (e) {
         problems.push(
-          `URGENT: could not roll ${name} back to '${prior.get(name) || 'unrestricted'}': ${e.message}`
+          `URGENT: could not roll ${name} back to '${want || 'unrestricted'}': ${e.message}. ` +
+          'Check it from the console before disconnecting.'
+        );
+        continue;
+      }
+      // Verify the rollback too. "Accepted but did no work" is the exact
+      // failure mode that made immediate verification necessary in the first
+      // place, and it is no less possible on the way back out.
+      try {
+        const back = (await readAddress(name)).join(',');
+        if (back !== want) {
+          problems.push(
+            `URGENT: ${name} was rolled back to '${want || 'unrestricted'}' but reads as ` +
+            `'${back || 'unrestricted'}'. Check it from the console before disconnecting.`
+          );
+        }
+      } catch (e) {
+        problems.push(
+          `URGENT: could not confirm ${name} was rolled back to '${want || 'unrestricted'}': ${e.message}`
         );
       }
     }
@@ -1799,6 +1846,12 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
       await rollback(`Binding ${name} failed.`);
       return problems;
     }
+
+    // Recorded as applied BEFORE verification, not after. The write has already
+    // landed on the device; if the read-back then throws or disagrees, this
+    // service still needs putting back. Adding it only on success would leave
+    // the one service that actually failed as the one service not rolled back.
+    applied.push(name);
 
     // Verify THIS write before making the next one. Verifying only at the end
     // means a bad value on an early service is discovered after every other
@@ -1848,8 +1901,6 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
       await rollback(`${name} did not read back as requested.`);
       return problems;
     }
-
-    applied.push(name);
   }
   console.log(`✓ /ip service bound to ${addressArg} (${ordered.length} services)`);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -1536,10 +1536,16 @@ async function readWanAddresses(mt, wans = []) {
   // directly - a pppoe-out client, say, whose parent ether is what is
   // configured but whose address lands on the client interface.
   // A pppoe uplink's address lands on the CLIENT interface, not the ethernet
-  // the config names. Without this the address is invisible and the uplink
-  // looks addressless forever.
+  // the config names, so the client is what must be watched. The parent is
+  // REPLACED rather than joined by it: on a normal pppoe setup the parent
+  // never carries an address at all, so leaving it in the set would keep
+  // `unresolved` permanently non-empty and management could never be hardened
+  // on a healthy pppoe router.
+  const pppoeParents = new Set();
   for (const wan of wans) {
-    if (wan && wan.type === 'pppoe' && wan.name) uplinks.add(`pppoe-${wan.name}`);
+    if (!wan || wan.type !== 'pppoe') continue;
+    if (wan.name) uplinks.add(`pppoe-${wan.name}`);
+    if (wan.interface) pppoeParents.add(wan.interface);
   }
 
   let discoveryFailed = null;
@@ -1554,6 +1560,10 @@ async function readWanAddresses(mt, wans = []) {
     // tool does not know about is never checked at all.
     discoveryFailed = e.message;
   }
+
+  // The parent is in the WAN interface list too, so it has to be removed after
+  // discovery as well as before it.
+  for (const parent of pppoeParents) uplinks.delete(parent);
 
   const found = [];
   const seen = new Set();

--- a/lib/router.js
+++ b/lib/router.js
@@ -1358,6 +1358,465 @@ async function configureRouterFirewall(mt, lanListVerified, fasttrack) {
   }
 }
 
+/* ------------------------------------------------------------------ */
+/* Management plane                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Source ranges an operator is allowed to name in `lan.management.allow`.
+ *
+ * Every one of them is non-globally-routable, so an extra entry can widen
+ * management reach across a VPN, a Tailscale tailnet or a second LAN, and can
+ * never name an address the internet can source from. That is the resolution
+ * of the tension between "there must be an escape hatch" and "WAN admin access
+ * must not be possible under ANY user config": the hatch exists, and its
+ * grammar cannot express the WAN.
+ *
+ * A double-NAT uplink can still be RFC1918 - the test device's ether1 sits on
+ * 192.168.4.0/22 - so a private entry is NOT proof by itself. Every entry is
+ * additionally checked at apply time against the addresses actually on the
+ * uplinks, which is the only check that can see a DHCP-assigned WAN.
+ */
+const PRIVATE_SCOPES = [
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '100.64.0.0/10',   // CGNAT - where Tailscale and WireGuard overlays live
+  '169.254.0.0/16',
+  '127.0.0.0/8'
+];
+
+// Cleartext management protocols. Neither is used by this tool - it drives
+// devices over SSH - and both carry the password in the clear.
+const CLEARTEXT_SERVICES = ['telnet', 'ftp'];
+
+// Interface-list-scoped management surfaces. These bypass /ip/service and the
+// IP firewall entirely: MAC-winbox and MAC-telnet run over layer 2, so an
+// attacker on the WAN broadcast domain reaches them without an IP at all.
+const L2_MANAGEMENT = [
+  {
+    label: 'MAC-telnet server',
+    read: ':put [/tool mac-server get allowed-interface-list]',
+    write: list => `/tool mac-server set allowed-interface-list=${list}`
+  },
+  {
+    label: 'MAC-winbox server',
+    read: ':put [/tool mac-server mac-winbox get allowed-interface-list]',
+    write: list => `/tool mac-server mac-winbox set allowed-interface-list=${list}`
+  },
+  {
+    label: 'neighbor discovery',
+    read: ':put [/ip neighbor discovery-settings get discover-interface-list]',
+    write: list => `/ip neighbor discovery-settings set discover-interface-list=${list}`
+  }
+];
+
+/**
+ * Is `inner` entirely contained within `outer`? Both are CIDR strings.
+ * @param {string} inner
+ * @param {string} outer
+ * @returns {boolean}
+ */
+function cidrWithin(inner, outer) {
+  const a = parseCidr(inner);
+  const b = parseCidr(outer);
+  if (!a || !b) return false;
+  // A shorter prefix is a bigger range, so it cannot fit inside a longer one.
+  if (a.prefix < b.prefix) return false;
+  return cidrContains(a.address, outer);
+}
+
+/**
+ * Does this CIDR name only non-globally-routable space?
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isPrivateCidr(value) {
+  return PRIVATE_SCOPES.some(scope => cidrWithin(value, scope));
+}
+
+/**
+ * Is this terse record flagged disabled?
+ *
+ * `print terse` never emits `disabled=yes`; disabled is an `X` in the flag
+ * letters between the index and the first field. lib/backup.js has the same
+ * logic for detail output, but requiring it here would make router.js and
+ * backup.js require each other.
+ *
+ * @param {string} record - One terse record
+ * @returns {boolean}
+ */
+function terseRecordDisabled(record) {
+  const flags = /^\s*\d+\s+([A-Z]+)\s/.exec(record || '');
+  return Boolean(flags && flags[1].includes('X'));
+}
+
+/**
+ * Split an address list off the device into its entries.
+ *
+ * RouterOS renders the same list two different ways, and both reach this
+ * function: `print terse` writes `address=a/24,b/24` while
+ * `:put [... get address]` writes `a/24;b/24` because :put renders an array.
+ * Splitting on only one of them silently reads a multi-entry list as one
+ * malformed entry, which would make verification pass or fail at random.
+ *
+ * @param {string} value - Raw value from either form
+ * @returns {string[]}
+ */
+function parseAddressList(value) {
+  return String(value || '')
+    .replace(/"/g, '')
+    .split(/[;,\s]+/)
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Build the source-address allow list the management services get bound to.
+ *
+ * The LAN network is always first and is not optional: the whole point is that
+ * RouterOS itself, not a firewall rule, refuses an off-LAN connection.
+ *
+ * RouterOS rejects `address=` with any host bit set ("value of address must
+ * have all host bits zero"), so entries are masked here rather than handed
+ * over as typed. Verified on RouterOS 7.18.2.
+ *
+ * @param {Object} lan - LAN configuration block
+ * @returns {{entries: string[], problems: string[]}}
+ */
+function managementAllowList(lan = {}) {
+  const problems = [];
+  const entries = [];
+
+  const lanNetwork = lan.address ? networkOf(lan.address) : null;
+  if (lanNetwork) entries.push(lanNetwork);
+
+  const extra = (lan.management && lan.management.allow) || [];
+  const list = Array.isArray(extra) ? extra : [extra];
+
+  for (const raw of list) {
+    const value = String(raw).trim();
+    const network = networkOf(value);
+    if (!network) {
+      problems.push(`lan.management.allow entry '${value}' is not valid CIDR (e.g. 10.9.0.0/24)`);
+      continue;
+    }
+    // Checked on the NETWORK form, so 8.8.8.8/1 cannot slip past by looking
+    // like a host address inside private space.
+    if (!isPrivateCidr(network)) {
+      problems.push(
+        `lan.management.allow entry '${value}' is publicly routable. ` +
+        'Management may only be opened to private space ' +
+        `(${PRIVATE_SCOPES.join(', ')}), never to an internet source.`
+      );
+      continue;
+    }
+    if (!entries.includes(network)) entries.push(network);
+  }
+
+  return { entries, problems };
+}
+
+/**
+ * Read every address currently sitting on an uplink.
+ *
+ * A DHCP or LTE uplink's address is not in the config, so a static check
+ * cannot see it. This is what catches the case a private-scope allow list
+ * cannot: a double-NAT WAN on 192.168.4.0/22, or a CGNAT WAN inside the
+ * 100.64.0.0/10 range that an overlay network also lives in.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Array<Object>} wans - Normalised uplinks
+ * @returns {Promise<string[]>} - CIDR addresses found on uplink interfaces
+ */
+async function readWanAddresses(mt, wans = []) {
+  const uplinks = new Set(wans.map(w => w.interface).filter(Boolean));
+
+  // The WAN list is authoritative for interfaces the config does not name
+  // directly - a pppoe-out client, say, whose parent ether is what is
+  // configured but whose address lands on the client interface.
+  try {
+    const members = await mt.exec(`/interface list member print terse where list=${WAN_LIST}`);
+    for (const record of terseRecords(members)) {
+      const iface = parseTerseRecord(record).interface;
+      if (iface) uplinks.add(iface.replace(/"/g, ''));
+    }
+  } catch (e) { /* fall back to the configured interfaces */ }
+
+  const found = [];
+  try {
+    const out = await mt.exec('/ip address print terse');
+    for (const record of terseRecords(out)) {
+      const fields = parseTerseRecord(record);
+      const iface = (fields['actual-interface'] || fields.interface || '').replace(/"/g, '');
+      if (!uplinks.has(iface)) continue;
+      if (fields.address && parseCidr(fields.address)) found.push(fields.address);
+    }
+  } catch (e) {
+    console.log(`⚠️  Could not read uplink addresses: ${e.message}`);
+  }
+  return found;
+}
+
+/**
+ * Parse `/user active print terse` into the sessions that hold an address.
+ *
+ * The device's own view is the one that matters. The address RouterOS compares
+ * against `/ip service address=` is the source address IT sees, which is not
+ * necessarily the address this process thinks it is using: a jump host, a NAT
+ * gateway or a VPN concentrator all rewrite it on the way. Asking the router
+ * is the only way to be right about all three.
+ *
+ * `via=local` is the serial console, which no IP restriction can affect.
+ *
+ * @param {string} output - Raw terse output
+ * @returns {Array<{address: string, via: string}>}
+ */
+function activeSessionAddresses(output) {
+  const sessions = [];
+  for (const record of terseRecords(output)) {
+    const fields = parseTerseRecord(record);
+    const address = (fields.address || '').replace(/"/g, '');
+    const via = (fields.via || '').replace(/"/g, '');
+    if (!address || ipToInt(address) === null) continue;
+    if (via === 'local' || via === 'console') continue;
+    sessions.push({ address, via });
+  }
+  return sessions;
+}
+
+/**
+ * Bind the management services to the LAN, so RouterOS itself refuses an
+ * off-LAN connection.
+ *
+ * WHY THIS EXISTS. Before this, every entry in `/ip service` listened on
+ * `address=""` - any source - and the only thing keeping the admin surface off
+ * the uplinks was one firewall rule, `router:input-drop-wan`. That rule works,
+ * but it is a single point of failure: delete it, reorder it, or add a
+ * permissive input rule above it and the whole management plane is exposed,
+ * behind whatever password the device has. Binding `address=` moves the check
+ * into RouterOS's own accept path, where no firewall edit can reach it. The
+ * firewall rule stays; the two layers fail independently.
+ *
+ * THE LOCKOUT CONSTRAINT, which outranks the exposure being fixed. This tool
+ * connects over SSH. Restricting `/ip service` while the operator is reaching
+ * the device from somewhere the restriction excludes would permanently lock
+ * them out of a remote router - far worse than the exposure. So the device is
+ * asked who is connected to it right now, and the restriction is SKIPPED, with
+ * a loud warning, unless every active session is covered. Not being able to
+ * tell counts as not covered.
+ *
+ * Skipping is a warning and not an unmet requirement, matching what
+ * configureRouterFirewall() already does when it cannot verify the LAN list:
+ * refusing to finish an otherwise-good apply because a safety guard fired
+ * would be its own kind of breakage, and the firewall rule still stands.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Object} lan - LAN configuration block
+ * @param {Array<Object>} wans - Normalised uplinks
+ * @param {boolean} lanListVerified - Whether the LAN list contains the bridge
+ * @returns {Promise<string[]>} - Unmet requirements, for the postcondition list
+ */
+async function configureManagementServices(mt, lan = {}, wans = [], lanListVerified = false) {
+  console.log('\n=== Restricting the Management Plane ===');
+
+  const { entries: allow, problems } = managementAllowList(lan);
+  const lanNetwork = lan.address ? networkOf(lan.address) : null;
+
+  if (!lanNetwork) {
+    console.log('⚠️  No usable lan.address, so /ip service was left listening on any address.');
+    console.log('    The router:input-drop-wan firewall rule is then the only thing keeping');
+    console.log('    management off the uplinks. Fix lan.address and apply again.');
+    return problems;
+  }
+
+  // A private-scope allow list is not proof on its own - a double-NAT uplink is
+  // RFC1918 too. Compare against what is actually on the uplinks right now.
+  const wanAddresses = await readWanAddresses(mt, wans);
+  const kept = [];
+  for (const entry of allow) {
+    const clash = wanAddresses.find(addr => cidrContains(addr.split('/')[0], entry));
+    if (!clash) {
+      kept.push(entry);
+      continue;
+    }
+    if (entry === lanNetwork) {
+      // Dropping it would leave an empty list, which means "no restriction".
+      // Keeping it is still strictly better than that, and the firewall rule
+      // covers the overlap, so this is reported rather than acted on.
+      kept.push(entry);
+      problems.push(
+        `lan.address ${lan.address} covers the uplink address ${clash}, so binding the ` +
+        'management services to the LAN network also admits that uplink. Renumber the LAN.'
+      );
+    } else {
+      problems.push(
+        `lan.management.allow entry '${entry}' covers the uplink address ${clash} and was ` +
+        'dropped - it would have opened management to the WAN side.'
+      );
+    }
+  }
+
+  let names;
+  try {
+    names = terseRecords(await mt.exec('/ip service print terse'))
+      .map(record => (parseTerseRecord(record).name || '').replace(/"/g, ''))
+      .filter(Boolean);
+  } catch (e) {
+    problems.push(`Could not read /ip service, so management was left unrestricted: ${e.message}`);
+    return problems;
+  }
+  if (names.length === 0) {
+    problems.push('Read /ip service but found no services, so management was left unrestricted');
+    return problems;
+  }
+
+  // THE LOCKOUT GUARD. Ask the device who is connected, not this process.
+  let sessions;
+  try {
+    sessions = activeSessionAddresses(await mt.exec('/user active print terse'));
+  } catch (e) {
+    console.log(`⚠️  Could not read the active sessions (${e.message}).`);
+    console.log('    Nothing was restricted: locking out a remote operator is worse than the');
+    console.log('    exposure this would have closed. The WAN drop rule still applies.');
+    return problems;
+  }
+
+  if (sessions.length === 0) {
+    // This session should always be in that list. An empty answer means the
+    // parse or the command is wrong, not that nobody is connected.
+    console.log('⚠️  The device reported no active sessions, which cannot be true while this');
+    console.log('    one is running. Treating it as "cannot tell" and restricting nothing.');
+    return problems;
+  }
+
+  const excluded = sessions.filter(s => !kept.some(entry => cidrContains(s.address, entry)));
+  if (excluded.length > 0) {
+    const who = excluded.map(s => `${s.address} (${s.via || 'unknown'})`).join(', ');
+    console.log(`⚠️  Skipped: ${who} would be locked out by ${kept.join(', ')}.`);
+    console.log('    Re-apply from the LAN and the restriction lands. If you manage this');
+    console.log('    router across a VPN, add that range to lan.management.allow.');
+    console.log('    The router:input-drop-wan firewall rule still keeps the uplinks closed.');
+    return problems;
+  }
+
+  const addressArg = kept.join(',');
+  // SSH goes last. It is the lifeline this session is riding on, so every other
+  // service proves the command shape works before it is pointed at our own.
+  const ordered = [...names.filter(n => n !== 'ssh'), ...names.filter(n => n === 'ssh')];
+
+  for (const name of ordered) {
+    try {
+      await mt.exec(`/ip service set [find name=${q(name)}] address=${q(addressArg)}`);
+    } catch (e) {
+      problems.push(`Could not bind the ${name} service to ${addressArg}: ${e.message}`);
+    }
+  }
+  console.log(`✓ /ip service bound to ${addressArg} (${ordered.length} services)`);
+
+  // Disabled services are bound too, above. That is deliberate: re-enabling one
+  // by hand later must not reopen the WAN.
+  if (lan.management && lan.management.cleartext === true) {
+    console.log('ℹ️  lan.management.cleartext is set, so telnet and ftp were left as they are.');
+    console.log('   They are LAN-bound like everything else, but both send the password in clear.');
+  } else {
+    for (const name of CLEARTEXT_SERVICES) {
+      if (!names.includes(name)) continue;
+      try {
+        await mt.exec(`/ip service set [find name=${q(name)}] disabled=yes`);
+      } catch (e) {
+        problems.push(`Could not disable the cleartext ${name} service: ${e.message}`);
+      }
+    }
+    console.log('✓ telnet and ftp disabled (cleartext, and unused by this tool)');
+  }
+
+  // VERIFY. "We issued the command" is not evidence, and a wrong value here is
+  // exactly the kind of failure that only shows up as a lockout on the next run.
+  const expected = new Set(kept);
+  for (const name of ordered) {
+    let got;
+    try {
+      got = parseAddressList(await mt.exec(`:put [/ip service get [find name=${q(name)}] address]`));
+    } catch (e) {
+      problems.push(`Could not read back the ${name} service address: ${e.message}`);
+      continue;
+    }
+    const same = got.length === expected.size && got.every(entry => expected.has(entry));
+    if (same) continue;
+
+    problems.push(
+      `The ${name} service reads back as ${got.length ? got.join(',') : 'unrestricted'}, ` +
+      `not ${addressArg}`
+    );
+
+    // SELF-HEAL. A wrong value on ssh does not cut the live session - RouterOS
+    // applies this to new connections - so the damage is invisible until the
+    // next connect fails. Clearing it trades the exposure back for reachability,
+    // which is the right way round, and the problem above still fails the apply.
+    if (name === 'ssh' && !sessions.every(s => got.some(entry => cidrContains(s.address, entry)))) {
+      try {
+        await mt.exec('/ip service set [find name="ssh"] address=""');
+        console.log('⚠️  Cleared the ssh address restriction: it did not cover this session.');
+      } catch (e) {
+        problems.push(`URGENT: ssh is restricted to ${got.join(',')} which excludes this session, and it could not be cleared: ${e.message}`);
+      }
+    }
+  }
+
+  if (!(lan.management && lan.management.cleartext === true)) {
+    for (const name of CLEARTEXT_SERVICES) {
+      if (!names.includes(name)) continue;
+      try {
+        const state = (await mt.exec(`:put [/ip service get [find name=${q(name)}] disabled]`)).trim();
+        if (!/^true$/i.test(state)) problems.push(`The ${name} service is still enabled`);
+      } catch (e) {
+        problems.push(`Could not confirm the ${name} service is disabled: ${e.message}`);
+      }
+    }
+  }
+
+  // Layer 2 management bypasses all of the above - no IP, no firewall input
+  // chain. Gated on the LAN list for the same reason the drop rule is: pointing
+  // MAC-winbox at a list that does not contain the bridge removes the recovery
+  // path that exists for exactly this kind of mistake.
+  if (!lanListVerified) {
+    console.log('⚠️  LAN list unverified, so MAC-telnet/MAC-winbox scoping was skipped.');
+    console.log('    Those run over layer 2 and ignore /ip service and the IP firewall.');
+    return problems;
+  }
+
+  for (const surface of L2_MANAGEMENT) {
+    try {
+      await mt.exec(surface.write(LAN_LIST));
+    } catch (e) {
+      problems.push(`Could not scope ${surface.label} to ${LAN_LIST}: ${e.message}`);
+      continue;
+    }
+    try {
+      const got = (await mt.exec(surface.read)).trim();
+      if (got !== LAN_LIST) problems.push(`${surface.label} reads back as '${got}', not ${LAN_LIST}`);
+    } catch (e) {
+      problems.push(`Could not read back ${surface.label}: ${e.message}`);
+    }
+  }
+  console.log(`✓ MAC-telnet, MAC-winbox and neighbor discovery scoped to the ${LAN_LIST} list`);
+
+  // RoMON is layer 2 as well and this tool does not own it, so it is reported
+  // rather than switched off. It is disabled from the factory, so this only
+  // fires for someone who turned it on deliberately.
+  try {
+    const romon = (await mt.exec(':put [/tool romon get enabled]')).trim();
+    if (/^true$/i.test(romon)) {
+      console.log('⚠️  RoMON is enabled. It carries management over layer 2, so it is not');
+      console.log('    covered by /ip service or the input chain. Forbid it on the uplinks');
+      console.log('    (/tool romon port add interface=<wan> forbid=yes) or turn it off.');
+    }
+  } catch (e) { /* not present on every build */ }
+
+  return problems;
+}
+
 /**
  * Serve DHCP to the LAN.
  * @param {MikroTikSSH} mt - Connected SSH session
@@ -1941,6 +2400,44 @@ async function backupRouterConfig(mt) {
     }
   } catch (e) { /* leave at the default */ }
 
+  // Management-plane restriction.
+  //
+  // Only recorded when the restriction is demonstrably IN PLACE. A device whose
+  // ssh service still listens on any address has simply never been hardened,
+  // and recording `cleartext: true` off the back of that would carry "leave
+  // telnet on" forward into every future apply - a backup/restore cycle would
+  // quietly undo the hardening. Read nothing, and the next apply hardens with
+  // the secure defaults.
+  try {
+    const serviceOut = await mt.exec('/ip service print terse');
+    const byName = new Map();
+    for (const record of terseRecords(serviceOut)) {
+      const name = (parseTerseRecord(record).name || '').replace(/"/g, '');
+      if (name) byName.set(name, record);
+    }
+
+    const sshRecord = byName.get('ssh');
+    const bound = sshRecord ? parseAddressList(parseTerseRecord(sshRecord).address) : [];
+    if (bound.length > 0) {
+      const management = {};
+      const lanNetwork = lan.address ? networkOf(lan.address) : null;
+      // The LAN network is implied by lan.address, so recording it as an extra
+      // allow entry would make every backup carry a redundant line.
+      const extra = bound.filter(entry => entry !== lanNetwork);
+      if (extra.length > 0) management.allow = extra;
+
+      const cleartextLive = CLEARTEXT_SERVICES
+        .filter(name => byName.has(name) && !terseRecordDisabled(byName.get(name)));
+      if (cleartextLive.length > 0) management.cleartext = true;
+
+      if (Object.keys(management).length > 0) lan.management = management;
+      console.log(`\u2713 Management bound to ${bound.join(', ')}`
+        + (cleartextLive.length ? ` (${cleartextLive.join(', ')} left enabled)` : ''));
+    }
+  } catch (e) {
+    console.log(`\u26a0\ufe0f  Could not read /ip service: ${e.message}`);
+  }
+
   const notify = await backupWanNotify(mt);
 
   return notify ? { lan, wan, notify } : { lan, wan };
@@ -2224,6 +2721,10 @@ async function configureRouter(config = {}) {
     await configureRouterFirewall(mt, lanListVerified, lan.fasttrack === true);
     const mssProblems = await configureMssClamp(mt, lan.mssClamp !== false);
 
+    // Runs after the firewall, so the LAN accept rule is already in place, and
+    // before anything that could change which address this session arrives on.
+    const managementProblems = await configureManagementServices(mt, lan, wans, lanListVerified);
+
     // The DHCP server and its network entry only make sense once the bridge
     // actually holds the LAN address, so add it before they are created.
     let lanAddressReady = true;
@@ -2250,6 +2751,7 @@ async function configureRouter(config = {}) {
     const problems = [
       ...(await verifyRouterState(mt, lan)),
       ...mssProblems,
+      ...managementProblems,
       ...wifiProblems,
       ...notifyProblems
     ];
@@ -2296,6 +2798,16 @@ module.exports = {
   configureRouterWifi,
   configureMssClamp,
   mssClampRuleIsCurrent,
+  configureManagementServices,
+  managementAllowList,
+  readWanAddresses,
+  terseRecordDisabled,
+  activeSessionAddresses,
+  parseAddressList,
+  cidrWithin,
+  isPrivateCidr,
+  PRIVATE_SCOPES,
+  CLEARTEXT_SERVICES,
   parseTerseRecord,
   terseRecords,
   MSS_CLAMP_COMMENT,

--- a/lib/router.js
+++ b/lib/router.js
@@ -1544,18 +1544,27 @@ async function readWanAddresses(mt, wans = []) {
   } catch (e) { /* fall back to the configured interfaces */ }
 
   const found = [];
+  const seen = new Set();
   try {
     const out = await mt.exec('/ip address print terse');
     for (const record of terseRecords(out)) {
       const fields = parseTerseRecord(record);
       const iface = (fields['actual-interface'] || fields.interface || '').replace(/"/g, '');
       if (!uplinks.has(iface)) continue;
-      if (fields.address && parseCidr(fields.address)) found.push(fields.address);
+      if (fields.address && parseCidr(fields.address)) {
+        found.push(fields.address);
+        seen.add(iface);
+      }
     }
   } catch (e) {
-    console.log(`⚠️  Could not read uplink addresses: ${e.message}`);
+    // An unreadable answer is not "no addresses". Saying so is the difference
+    // between failing closed and silently deciding the uplinks are harmless.
+    return { addresses: [], unresolved: [...uplinks], readFailed: e.message };
   }
-  return found;
+
+  // An uplink with no address YET is the dangerous case: DHCP or LTE can hand
+  // it one a moment later, inside a range we just decided was safe to allow.
+  return { addresses: found, unresolved: [...uplinks].filter(i => !seen.has(i)), readFailed: null };
 }
 
 /**
@@ -1574,15 +1583,27 @@ async function readWanAddresses(mt, wans = []) {
  */
 function activeSessionAddresses(output) {
   const sessions = [];
+  const unreadable = [];
   for (const record of terseRecords(output)) {
     const fields = parseTerseRecord(record);
     const address = (fields.address || '').replace(/"/g, '');
     const via = (fields.via || '').replace(/"/g, '');
-    if (!address || ipToInt(address) === null) continue;
+
+    // A session on the console is not reached over the network, so no address
+    // restriction can lock it out. Only these are safe to disregard.
     if (via === 'local' || via === 'console') continue;
+
+    // Anything else we cannot read is a session we cannot prove is covered:
+    // an IPv6 peer, a zone-decorated address, a shape this parser does not
+    // know. Dropping it silently is how "cannot tell" turns into "assumed
+    // fine" - the caller must treat it as blocking.
+    if (!address || ipToInt(address) === null) {
+      unreadable.push({ raw: record.trim(), via });
+      continue;
+    }
     sessions.push({ address, via });
   }
-  return sessions;
+  return { sessions, unreadable };
 }
 
 /**
@@ -1632,23 +1653,46 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
 
   // A private-scope allow list is not proof on its own - a double-NAT uplink is
   // RFC1918 too. Compare against what is actually on the uplinks right now.
-  const wanAddresses = await readWanAddresses(mt, wans);
+  const { addresses: wanAddresses, unresolved, readFailed } = await readWanAddresses(mt, wans);
+
+  // Fail CLOSED on an uplink whose address we cannot see. A private range is
+  // not proof of anything - this device's own WAN is 192.168.4.0/22 - so the
+  // only check that can catch a clash is against the address actually on the
+  // uplink. No address means no check, and a DHCP or LTE uplink can acquire one
+  // inside an allowed range moments after we finish.
+  const uplinkStateUnknown = Boolean(readFailed) || unresolved.length > 0;
+  if (uplinkStateUnknown && allow.some(entry => entry !== lanNetwork)) {
+    const why = readFailed
+      ? `the uplink addresses could not be read (${readFailed})`
+      : `${unresolved.join(', ')} has no address yet`;
+    console.log(`⚠️  Dropping every lan.management.allow entry: ${why},`);
+    console.log('    so none of them can be proven not to cover an uplink.');
+    problems.push(
+      `lan.management.allow was ignored because ${why}. Re-apply once every uplink has ` +
+      'an address, or remove the entry.'
+    );
+  }
+
   const kept = [];
   for (const entry of allow) {
+    if (entry !== lanNetwork && uplinkStateUnknown) continue;
     const clash = wanAddresses.find(addr => cidrContains(addr.split('/')[0], entry));
     if (!clash) {
       kept.push(entry);
       continue;
     }
     if (entry === lanNetwork) {
-      // Dropping it would leave an empty list, which means "no restriction".
-      // Keeping it is still strictly better than that, and the firewall rule
-      // covers the overlap, so this is reported rather than acted on.
-      kept.push(entry);
+      // Binding to a LAN network that contains a live uplink address would
+      // install an allow-list that ADMITS the WAN, while reporting that
+      // management had been locked to the LAN. Claiming a protection we are not
+      // providing is worse than not providing it: refuse, and leave the
+      // firewall rule as the honest single layer it already was.
       problems.push(
-        `lan.address ${lan.address} covers the uplink address ${clash}, so binding the ` +
-        'management services to the LAN network also admits that uplink. Renumber the LAN.'
+        `lan.address ${lan.address} covers the uplink address ${clash}. Binding management ` +
+        'to that network would also admit the uplink, so nothing was bound. Renumber the ' +
+        'LAN off the uplink range and apply again.'
       );
+      return problems;
     } else {
       problems.push(
         `lan.management.allow entry '${entry}' covers the uplink address ${clash} and was ` +
@@ -1673,12 +1717,23 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
 
   // THE LOCKOUT GUARD. Ask the device who is connected, not this process.
   let sessions;
+  let unreadable;
   try {
-    sessions = activeSessionAddresses(await mt.exec('/user active print terse'));
+    ({ sessions, unreadable } = activeSessionAddresses(await mt.exec('/user active print terse')));
   } catch (e) {
     console.log(`⚠️  Could not read the active sessions (${e.message}).`);
     console.log('    Nothing was restricted: locking out a remote operator is worse than the');
     console.log('    exposure this would have closed. The WAN drop rule still applies.');
+    return problems;
+  }
+
+  if (unreadable.length > 0) {
+    // Not "ignore the ones we cannot read" - any session we cannot place is a
+    // session we cannot prove survives the restriction.
+    console.log(`⚠️  ${unreadable.length} active session(s) could not be read:`);
+    unreadable.forEach(u => console.log(`      ${u.raw}`));
+    console.log('    One of them could be this connection, so nothing was restricted.');
+    console.log('    The router:input-drop-wan firewall rule still keeps the uplinks closed.');
     return problems;
   }
 
@@ -1705,12 +1760,96 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
   // service proves the command shape works before it is pointed at our own.
   const ordered = [...names.filter(n => n !== 'ssh'), ...names.filter(n => n === 'ssh')];
 
+  const readAddress = async name =>
+    parseAddressList(await mt.exec(`:put [/ip service get [find name=${q(name)}] address]`));
+
+  // Record what each service looked like BEFORE touching anything, so a
+  // half-finished run can be put back. Without this, a failure partway through
+  // leaves some services bound and others open - and if it failed before ssh,
+  // every alternative recovery path is restricted while the lifeline is not.
+  const prior = new Map();
+  try {
+    for (const name of ordered) prior.set(name, (await readAddress(name)).join(','));
+  } catch (e) {
+    problems.push(`Could not read the current /ip service addresses, so nothing was changed: ${e.message}`);
+    return problems;
+  }
+
+  const applied = [];
+  const rollback = async why => {
+    if (applied.length === 0) return;
+    console.log(`⚠️  ${why}`);
+    console.log(`    Rolling back ${applied.length} service(s) to how they were.`);
+    for (const name of applied.reverse()) {
+      try {
+        await mt.exec(`/ip service set [find name=${q(name)}] address=${q(prior.get(name))}`);
+      } catch (e) {
+        problems.push(
+          `URGENT: could not roll ${name} back to '${prior.get(name) || 'unrestricted'}': ${e.message}`
+        );
+      }
+    }
+  };
+
   for (const name of ordered) {
     try {
       await mt.exec(`/ip service set [find name=${q(name)}] address=${q(addressArg)}`);
     } catch (e) {
       problems.push(`Could not bind the ${name} service to ${addressArg}: ${e.message}`);
+      await rollback(`Binding ${name} failed.`);
+      return problems;
     }
+
+    // Verify THIS write before making the next one. Verifying only at the end
+    // means a bad value on an early service is discovered after every other
+    // service has already been changed.
+    let got;
+    try {
+      got = await readAddress(name);
+    } catch (e) {
+      problems.push(`Could not read back the ${name} service address: ${e.message}`);
+      await rollback(`Could not verify ${name}.`);
+      return problems;
+    }
+
+    const expected = new Set(kept);
+    const same = got.length === expected.size && got.every(entry => expected.has(entry));
+    if (!same) {
+      problems.push(
+        `The ${name} service reads back as ${got.length ? got.join(',') : 'unrestricted'}, not ${addressArg}`
+      );
+
+      // SELF-HEAL, for ssh only. A wrong value here does not cut the live
+      // session - RouterOS applies it to NEW connections - so the damage is
+      // invisible until the next connect fails. Clear it, then CONFIRM the
+      // clear: exec() rejects on a RouterOS failure now, but a command can also
+      // be accepted and not do what was asked, and this is the one place where
+      // being wrong means never reaching the device again.
+      if (name === 'ssh' && !sessions.every(sn => got.some(entry => cidrContains(sn.address, entry)))) {
+        try {
+          await mt.exec('/ip service set [find name="ssh"] address=""');
+          const after = await readAddress('ssh');
+          if (after.length > 0) {
+            problems.push(
+              `URGENT: ssh is restricted to ${after.join(',')}, which excludes this session, ` +
+              'and clearing it did not take. Fix it from the console before disconnecting.'
+            );
+          } else {
+            console.log('⚠️  Cleared the ssh address restriction: it did not cover this session.');
+          }
+        } catch (e) {
+          problems.push(
+            `URGENT: ssh is restricted to ${got.join(',')} which excludes this session, ` +
+            `and it could not be cleared: ${e.message}. Fix it from the console before disconnecting.`
+          );
+        }
+      }
+
+      await rollback(`${name} did not read back as requested.`);
+      return problems;
+    }
+
+    applied.push(name);
   }
   console.log(`✓ /ip service bound to ${addressArg} (${ordered.length} services)`);
 
@@ -1731,38 +1870,9 @@ async function configureManagementServices(mt, lan = {}, wans = [], lanListVerif
     console.log('✓ telnet and ftp disabled (cleartext, and unused by this tool)');
   }
 
-  // VERIFY. "We issued the command" is not evidence, and a wrong value here is
-  // exactly the kind of failure that only shows up as a lockout on the next run.
-  const expected = new Set(kept);
-  for (const name of ordered) {
-    let got;
-    try {
-      got = parseAddressList(await mt.exec(`:put [/ip service get [find name=${q(name)}] address]`));
-    } catch (e) {
-      problems.push(`Could not read back the ${name} service address: ${e.message}`);
-      continue;
-    }
-    const same = got.length === expected.size && got.every(entry => expected.has(entry));
-    if (same) continue;
-
-    problems.push(
-      `The ${name} service reads back as ${got.length ? got.join(',') : 'unrestricted'}, ` +
-      `not ${addressArg}`
-    );
-
-    // SELF-HEAL. A wrong value on ssh does not cut the live session - RouterOS
-    // applies this to new connections - so the damage is invisible until the
-    // next connect fails. Clearing it trades the exposure back for reachability,
-    // which is the right way round, and the problem above still fails the apply.
-    if (name === 'ssh' && !sessions.every(s => got.some(entry => cidrContains(s.address, entry)))) {
-      try {
-        await mt.exec('/ip service set [find name="ssh"] address=""');
-        console.log('⚠️  Cleared the ssh address restriction: it did not cover this session.');
-      } catch (e) {
-        problems.push(`URGENT: ssh is restricted to ${got.join(',')} which excludes this session, and it could not be cleared: ${e.message}`);
-      }
-    }
-  }
+  // Each service was verified immediately after it was written, above, and a
+  // mismatch aborts and rolls back there. A second sweep here would only
+  // re-read values already proven.
 
   if (!(lan.management && lan.management.cleartext === true)) {
     for (const name of CLEARTEXT_SERVICES) {

--- a/lib/validate-router.js
+++ b/lib/validate-router.js
@@ -8,7 +8,7 @@
  */
 
 const { CIDR, IPV4, IP_RANGE, DURATION, IDENTIFIER, HTTP_URL, NOTIFY_TITLE } = require('./routeros-args');
-const { normalizeWans } = require('./router');
+const { normalizeWans, managementAllowList } = require('./router');
 
 const VALID_WAN_TYPES = ['dhcp', 'static', 'pppoe', 'lte'];
 // Shape alone is not enough: 999.999.999.999/99 matched the old pattern.
@@ -92,6 +92,61 @@ function validateNotify(notify, label, errors, warnings) {
 }
 
 /**
+ * Validate the optional `lan.management` block.
+ *
+ * This block can only ever WIDEN which sources reach the management services,
+ * so it is the one place a user config could undo the "no WAN admin access"
+ * property. It cannot: every entry has to name non-globally-routable space,
+ * which is checked here, and is checked again at apply time against the
+ * addresses actually on the uplinks (a double-NAT WAN is RFC1918 too, so the
+ * static check alone is not sufficient).
+ *
+ * @param {Object} management - The lan.management block
+ * @param {Object} lan - The whole LAN block, for context
+ * @param {string} label - Prefix for messages
+ * @param {string[]} errors - Collected errors, appended to
+ * @param {string[]} warnings - Collected warnings, appended to
+ */
+function validateManagement(management, lan, label, errors, warnings) {
+  if (typeof management !== 'object' || management === null || Array.isArray(management)) {
+    errors.push(`${label}: lan.management must be a mapping (allow, cleartext)`);
+    return;
+  }
+
+  // Compared with `=== true`, so a stringy "true" from YAML would read as
+  // "disable them" and silently do the opposite of what was written.
+  if (management.cleartext !== undefined && typeof management.cleartext !== 'boolean') {
+    errors.push(`${label}: lan.management.cleartext must be true or false`);
+  }
+  if (management.cleartext === true) {
+    warnings.push(
+      `${label}: lan.management.cleartext keeps telnet and ftp enabled. Both send the ` +
+      'password in clear text. They stay bound to the LAN, so this is a LAN-sniffing risk, ' +
+      'not a WAN one.'
+    );
+  }
+
+  if (management.allow === undefined) return;
+  if (!Array.isArray(management.allow)) {
+    errors.push(`${label}: lan.management.allow must be a list of CIDR ranges`);
+    return;
+  }
+
+  // managementAllowList() is what the apply actually uses, so validating its
+  // output means the two can never disagree about which entries are acceptable.
+  const { problems } = managementAllowList(lan);
+  problems.forEach(problem => errors.push(`${label}: ${problem}`));
+
+  if (management.allow.length > 0 && problems.length === 0) {
+    warnings.push(
+      `${label}: lan.management.allow widens management beyond the LAN to ` +
+      `${management.allow.join(', ')}. Those ranges are private, so they cannot be an ` +
+      'internet source, but anything that can reach them can reach the admin interfaces.'
+    );
+  }
+}
+
+/**
  * Validate the lan and wan blocks of a router-role configuration.
  *
  * Returns errors and warnings separately. The distinction matters: an error
@@ -122,6 +177,10 @@ function validateRouterConfig(config, label = 'Router') {
 
   if (config.notify !== undefined) {
     validateNotify(config.notify, label, errors, warnings);
+  }
+
+  if (lan.management !== undefined) {
+    validateManagement(lan.management, lan, label, errors, warnings);
   }
 
   if (!Array.isArray(wans) || wans.length === 0) {

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -306,6 +306,13 @@ function runningQuery(name) {
  *     sleep for. A slow or timing-out SSH read burns real time too, and
  *     counting only sleeps ran well past the budget exactly when reads were
  *     slowest - the failure mode the budget exists to bound.
+ *   - KNOWN BOUND, accepted deliberately: `timeoutMs` caps when a NEW round may
+ *     start, not how long a round already in flight may take. exec() has its own
+ *     30s timeout, so a round over N unresponsive interfaces can overrun by up to
+ *     N x 30s. Cutting a round short instead would judge the interfaces later in
+ *     the map on a stale result and report healthy DFS radios as dead - a wrong
+ *     answer, where this is only a slow one. It only happens once the device has
+ *     already stopped answering.
  *   - A round is an ATOMIC SNAPSHOT. Once a round starts, every unresolved name
  *     is read in it. Breaking out mid-round on the deadline would judge the
  *     names later in the map on their previous round's result, so several
@@ -518,8 +525,22 @@ async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) 
     const master = await mt.exec(
       `:put [${wifiPath}/get [find name=${q(interfaceName)}] master-interface]`
     );
-    isVirtual = Boolean(master && master.trim() && !/^\s*$/.test(master));
-    classified = true;
+    // Structural, not merely non-empty. exec() now rejects a RouterOS failure,
+    // so error text can no longer arrive here wearing a success exit - but the
+    // consequence of getting this wrong is bouncing a MASTER radio and cutting
+    // every client, including possibly the operator's own link. So require the
+    // answer to actually look like an interface name before believing it.
+    const value = (master || '').trim();
+    if (value === '') {
+      isVirtual = false;          // no master-interface => this IS a master
+      classified = true;
+    } else if (/^[A-Za-z0-9_.:-]{1,64}$/.test(value)) {
+      isVirtual = true;
+      classified = true;
+    } else {
+      // Something we do not recognise. Do not toggle on a guess.
+      classifyError = new Error(`unrecognised master-interface value ${JSON.stringify(value)}`);
+    }
   } catch (e) {
     // Cannot tell what this is. Never toggle it - but do not call it healthy
     // either, or a dead VAP could hide behind a failed lookup.

--- a/lib/wifi-config.js
+++ b/lib/wifi-config.js
@@ -294,6 +294,88 @@ function runningQuery(name) {
 }
 
 /**
+ * Poll `running` on a set of interfaces against ONE shared deadline.
+ *
+ * Both callers need the same awkward properties, and having two copies of them
+ * is how they drift apart:
+ *
+ *   - ONE deadline for all the names, not one each. A controller with 20 dead
+ *     CAP radios would otherwise stall the apply for the timeout times twenty,
+ *     and the device runs those channel checks concurrently anyway.
+ *   - Time is measured against the CLOCK, not against the time we asked to
+ *     sleep for. A slow or timing-out SSH read burns real time too, and
+ *     counting only sleeps ran well past the budget exactly when reads were
+ *     slowest - the failure mode the budget exists to bound.
+ *   - A round is an ATOMIC SNAPSHOT. Once a round starts, every unresolved name
+ *     is read in it. Breaking out mid-round on the deadline would judge the
+ *     names later in the map on their previous round's result, so several
+ *     radios finishing near the deadline would see the first pass and the rest
+ *     falsely reported dead. The deadline is checked BETWEEN rounds; the
+ *     overrun is bounded by one round of reads.
+ *   - A read failure is NOT fatal. A transient error mid-recovery must not
+ *     condemn an interface that is about to come up; it is only reported if it
+ *     never resolves.
+ *
+ * @param {MikroTikSSH} mt - Connected SSH session
+ * @param {Iterable<string>} names - Interfaces to watch
+ * @param {Object} [options]
+ * @param {number} [options.timeoutMs=90000] - Shared budget
+ * @param {number} [options.pollMs=5000] - Gap between rounds
+ * @param {Function} [options.sleep] - Injectable delay, for tests
+ * @param {Function} [options.now] - Injectable clock, for tests
+ * @param {Function} [options.onUp] - Called with (name, elapsedMs) as each comes up
+ * @returns {Promise<{pending: Map<string, Error|null>, elapsedMs: number}>}
+ *          `pending` holds the names still not running, mapped to the last read
+ *          error when the reads themselves were failing.
+ */
+async function pollUntilRunning(mt, names, options = {}) {
+  const {
+    timeoutMs = 90000,
+    pollMs = 5000,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now = () => Date.now(),
+    onUp = () => {}
+  } = options;
+
+  // A Map also de-duplicates the names.
+  const pending = new Map([...names].map(name => [name, null]));
+  if (pending.size === 0) return { pending, elapsedMs: 0 };
+
+  const started = now();
+  const elapsed = () => now() - started;
+
+  // Belt and braces: even a caller that passes a frozen clock and a no-op
+  // sleep cannot spin here for ever.
+  const maxRounds = Math.ceil(Math.max(timeoutMs, 0) / Math.max(pollMs, 1)) + 1;
+
+  for (let round = 1; ; round++) {
+    for (const name of [...pending.keys()]) {
+      try {
+        const out = await mt.exec(runningQuery(name));
+        if (/true/i.test(out || '')) {
+          onUp(name, elapsed());
+          pending.delete(name);
+        } else {
+          pending.set(name, null);
+        }
+      } catch (e) {
+        pending.set(name, e);
+      }
+    }
+
+    if (pending.size === 0) break;
+    if (elapsed() >= timeoutMs || round >= maxRounds) break;
+
+    // Never overshoot the shared budget.
+    const step = Math.min(pollMs, timeoutMs - elapsed());
+    if (step <= 0) break;
+    await sleep(step);
+  }
+
+  return { pending, elapsedMs: elapsed() };
+}
+
+/**
  * Look again at master radios that were still starting up.
  *
  * A master is never bounced, so the only safe way to tell a DFS availability
@@ -304,7 +386,8 @@ function runningQuery(name) {
  * @param {MikroTikSSH} mt - Connected SSH session
  * @param {string[]} names - Interfaces deferred earlier
  * @param {Object} [options]
- * @param {number} [options.delayMs=5000] - Settle time before re-checking
+ * @param {number} [options.timeoutMs=90000] - Shared budget for all the radios
+ * @param {number} [options.pollMs=5000] - Gap between rounds
  * @param {Function} [options.sleep] - Injectable delay, for tests
  * @returns {Promise<string[]>} - Problems for interfaces still not running
  */
@@ -319,71 +402,32 @@ async function recheckPendingMasters(mt, names, options = {}) {
     // dead, so poll until they come up instead.
     timeoutMs = 90000,
     pollMs = 5000,
-    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
-    // Injectable so tests are deterministic and do not wait in real time.
-    now = () => Date.now()
+    sleep,
+    now
   } = options;
 
-  // ONE deadline for all of them, not one each. CAC and provisioning happen
-  // concurrently on the device, so polling serially would multiply the wait by
-  // the number of radios - a controller with 20 dead CAP radios would otherwise
-  // stall the apply for half an hour. Map also de-duplicates the names.
-  const pending = new Map(names.map(name => [name, null]));
-
   console.log('\n=== Re-checking radios that were still starting ===');
-  console.log(`  Waiting up to ${Math.round(timeoutMs / 1000)}s in total for ${pending.size} radio(s).`);
+  console.log(`  Waiting up to ${Math.round(timeoutMs / 1000)}s in total for ${new Set(names).size} radio(s).`);
   console.log('  A DFS availability check takes about 60s, and setting a channel can restart it.');
 
-  // Measured against the clock, NOT against time we asked to sleep for. A slow
-  // or timing-out SSH read consumes real time too, and counting only sleeps let
-  // the function run well past its budget exactly when reads were slowest.
-  const started = now();
-  const elapsed = () => now() - started;
-
-  // Belt and braces: even a clock that never advances cannot spin here.
-  const maxRounds = Math.ceil(timeoutMs / Math.max(pollMs, 1)) + 1;
-
-  // A round is an ATOMIC SNAPSHOT: once it starts, every unresolved radio is
-  // read in it. Breaking out mid-round on the deadline would judge the radios
-  // later in the map on their previous round's result - so several DFS checks
-  // finishing near the deadline would see the first radio pass and the rest
-  // falsely reported dead. The deadline is therefore only checked BETWEEN
-  // rounds; the overrun is bounded by one round's worth of reads.
-  for (let round = 1; ; round++) {
-    for (const name of [...pending.keys()]) {
-      try {
-        const out = await mt.exec(runningQuery(name));
-        if (/true/i.test(out || '')) {
-          const secs = Math.round(elapsed() / 1000);
-          console.log(`  ✓ ${name} is now running${secs ? ` (after ${secs}s)` : ''}`);
-          pending.delete(name);
-        } else {
-          pending.set(name, null);
-        }
-      } catch (e) {
-        // Keep polling: a transient read failure mid-CAC should not condemn a
-        // radio that is about to come up. Reported only if it never resolves.
-        pending.set(name, e);
-      }
-
+  const { pending, elapsedMs } = await pollUntilRunning(mt, names, {
+    timeoutMs,
+    pollMs,
+    ...(sleep ? { sleep } : {}),
+    ...(now ? { now } : {}),
+    onUp: (name, ms) => {
+      const secs = Math.round(ms / 1000);
+      console.log(`  \u2713 ${name} is now running${secs ? ` (after ${secs}s)` : ''}`);
     }
+  });
 
-    if (pending.size === 0) break;
-    if (elapsed() >= timeoutMs || round >= maxRounds) break;
-
-    // Never overshoot the shared budget.
-    const step = Math.min(pollMs, timeoutMs - elapsed());
-    if (step <= 0) break;
-    await sleep(step);
-  }
-
-  const waitedSecs = Math.round(elapsed() / 1000);
+  const waitedSecs = Math.round(elapsedMs / 1000);
   for (const [name, readError] of pending) {
     const problem = readError
       ? `${name} could not be re-checked: ${readError.message}`
       : `${name} is configured but still not running after ${waitedSecs}s - ` +
         'its SSID is not on the air';
-    console.log(`  ✗ ${problem}`);
+    console.log(`  \u2717 ${problem}`);
     problems.push(problem);
   }
 
@@ -413,18 +457,44 @@ async function recheckPendingMasters(mt, names, options = {}) {
  * @param {MikroTikSSH} mt - Connected SSH session
  * @param {string} wifiPath - Base wifi path for this package
  * @param {string} interfaceName - Interface to check
+ * WHY THE WAIT IS A POLL AND NOT A FIXED DELAY (fixed in 6.2.4). 6.2.3 waited a
+ * flat 3s after the toggle and gave up after two of them - about 6s of settle.
+ * On the live Chateau that produced a FALSE NEGATIVE: the apply exhausted the
+ * budget, reported "wifi2-ssid2 is configured but not running" and exited
+ * INCOMPLETE, and the interface came up on its own moments later. A later apply
+ * on the same device recovered inside the budget and passed. So it was marginal,
+ * and it failed in the direction that breaks any automation gating on the exit
+ * code. Recovery after a FRESH create is slower than recovery from a disabled
+ * state, which was measured at 3.9s.
+ *
+ * Polling costs nothing when the interface is healthy - it returns on the first
+ * read - so the budget only spends time on a genuine failure. That makes a
+ * generous budget nearly free, which is why it is 60s rather than something
+ * tuned tightly to the observed 6s.
+ *
+ * The honest failure is kept: when the budget genuinely expires the problem is
+ * still reported, and that was the good part of 6.2.3.
+ *
  * @param {Object} [options]
  * @param {number} [options.attempts=3] - Total attempts, including the first check
- * @param {number} [options.delayMs=3000] - Settle time after enabling
+ * @param {number} [options.timeoutMs=60000] - Settle budget shared across the retries
+ * @param {number} [options.pollMs=3000] - Gap between `running` reads while settling
  * @param {Function} [options.sleep] - Injectable delay, for tests
+ * @param {Function} [options.now] - Injectable clock, for tests
  * @returns {Promise<string|null>} - A problem description, or null when up
  */
 async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) {
   const {
     attempts = 3,
-    delayMs = 3000,
+    // Shared across every retry, so raising `attempts` cannot multiply the
+    // worst-case wait. 60s is an order of magnitude above every recovery
+    // actually observed on hardware, and still well under the 90s budget the
+    // master re-check uses for a DFS availability check.
+    timeoutMs = 60000,
+    pollMs = 3000,
     pendingMasters = null,
-    sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now = () => Date.now()
   } = options;
 
   // `running` is the authoritative signal and is unambiguous, unlike parsing
@@ -457,59 +527,75 @@ async function ensureWifiInterfaceUp(mt, wifiPath, interfaceName, options = {}) 
     classifyError = e;
   }
 
+  // Attempt 1 is a plain read, not a poll: a healthy interface must not cost a
+  // poll cycle, and the overwhelmingly common case is that it is already up.
   let lastError = null;
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      if (await isUp()) {
-        if (attempt > 1) console.log(`  ✓ ${interfaceName} came up on attempt ${attempt}`);
-        return null;
-      }
-    } catch (e) {
-      lastError = e;
-      // Cannot read state; there is nothing useful to retry against.
-      const problem = `${interfaceName} could not be read back after configuration: ${e.message}`;
-      console.log(`  ✗ ${problem}`);
+  try {
+    if (await isUp()) return null;
+  } catch (e) {
+    // Cannot read state; there is nothing useful to retry against.
+    const problem = `${interfaceName} could not be read back after configuration: ${e.message}`;
+    console.log(`  \u2717 ${problem}`);
+    return problem;
+  }
+
+  if (!isVirtual) {
+    // Never touch a master. But "not running" is not proof of health either: a
+    // bad channel, a radio rejection or a driver fault reads exactly like a DFS
+    // availability check. So defer it and look again once the rest of the apply
+    // has given it time to settle.
+    if (!classified) {
+      const problem = `${interfaceName} could not be identified as master or virtual` +
+        `${classifyError ? `: ${classifyError.message}` : ''} - left untouched, and it is not running`;
+      console.log(`  \u2717 ${problem}`);
       return problem;
     }
-
-    if (!isVirtual) {
-      // Never touch a master. But "not running" is not proof of health either:
-      // a bad channel, a radio rejection or a driver fault reads exactly like a
-      // DFS availability check. So defer it and look again once the rest of the
-      // apply has given it time to settle.
-      if (!classified) {
-        const problem = `${interfaceName} could not be identified as master or virtual` +
-          `${classifyError ? `: ${classifyError.message}` : ''} - left untouched, and it is not running`;
-        console.log(`  ✗ ${problem}`);
-        return problem;
-      }
-      console.log(`  ⚠️  ${interfaceName} is not running yet - it is a master radio, so it is left alone.`);
-      console.log('     A DFS availability check or a CAP still provisioning looks like this.');
-      if (pendingMasters) {
-        if (!pendingMasters.includes(interfaceName)) pendingMasters.push(interfaceName);
-        console.log('     Will re-check before the run finishes.');
-        return null;
-      }
-      const problem = `${interfaceName} is configured but not running - its SSID is not on the air`;
-      console.log(`  ✗ ${problem}`);
-      return problem;
+    console.log(`  \u26a0\ufe0f  ${interfaceName} is not running yet - it is a master radio, so it is left alone.`);
+    console.log('     A DFS availability check or a CAP still provisioning looks like this.');
+    if (pendingMasters) {
+      if (!pendingMasters.includes(interfaceName)) pendingMasters.push(interfaceName);
+      console.log('     Will re-check before the run finishes.');
+      return null;
     }
+    const problem = `${interfaceName} is configured but not running - its SSID is not on the air`;
+    console.log(`  \u2717 ${problem}`);
+    return problem;
+  }
 
-    if (attempt === attempts) break;
+  // A virtual AP, and it is down. Toggle it, then WAIT AND WATCH rather than
+  // waiting a fixed moment and asking once.
+  const retries = Math.max(attempts - 1, 0);
+  const perRetryMs = Math.ceil(Math.max(timeoutMs, 0) / Math.max(retries, 1));
+  const started = now();
 
-    console.log(`  ⚠️  ${interfaceName} is not running, retrying (${attempt}/${attempts - 1})`);
+  for (let retry = 1; retry <= retries; retry++) {
+    console.log(`  \u26a0\ufe0f  ${interfaceName} is not running, retrying (${retry}/${retries})`);
     try {
       // This interface only. Never the master.
       await mt.exec(`${wifiPath} set [find name=${q(interfaceName)}] disabled=yes`);
       await sleep(500);
       await mt.exec(`${wifiPath} set [find name=${q(interfaceName)}] disabled=no`);
-      await sleep(delayMs);
     } catch (e) {
-      lastError = e;
       const problem = `${interfaceName} could not be restarted: ${e.message}`;
-      console.log(`  ✗ ${problem}`);
+      console.log(`  \u2717 ${problem}`);
       return problem;
     }
+
+    // Split evenly so a later retry still gets a turn, and clamped by what is
+    // left of the shared budget so the total cannot run away.
+    const remaining = Math.max(timeoutMs - (now() - started), 0);
+    const { pending } = await pollUntilRunning(mt, [interfaceName], {
+      timeoutMs: Math.min(perRetryMs, remaining),
+      pollMs,
+      sleep,
+      now,
+      onUp: (name, ms) => {
+        const secs = Math.round(ms / 1000);
+        console.log(`  \u2713 ${name} came up on attempt ${retry + 1}${secs ? ` (after ${secs}s)` : ''}`);
+      }
+    });
+    if (pending.size === 0) return null;
+    lastError = pending.get(interfaceName) || lastError;
   }
 
   // Surface the device's own explanation when it left one.
@@ -910,6 +996,7 @@ module.exports = {
   configureWifiInterface,
   ensureWifiInterfaceUp,
   recheckPendingMasters,
+  pollUntilRunning,
   runningQuery,
   getSwappedRadioCaps,
   getRadioBandMapping,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/router.example.yaml
+++ b/router.example.yaml
@@ -58,6 +58,48 @@ lan:
   # failover cleanliness.
   # fasttrack: true
 
+  # -------------------------------------------------------------------------
+  # Management plane (optional, and hardened whether or not you write it)
+  # -------------------------------------------------------------------------
+  # Applying ALWAYS binds every /ip service entry - ssh, www, winbox, api, and
+  # the disabled ones too - to the network derived from lan.address above, so
+  # RouterOS itself refuses a connection from off-LAN. telnet and ftp are
+  # disabled, and MAC-telnet, MAC-winbox and neighbor discovery are scoped to
+  # the LAN interface list, because those run over layer 2 and ignore both the
+  # service binding and the firewall.
+  #
+  # You do not need this block. It only exists to widen or soften the defaults,
+  # and NOTHING you can write in it opens management to the WAN.
+  #
+  # management:
+  #   allow:
+  #     - 100.64.0.0/10     # a Tailscale/WireGuard overlay
+  #     - 10.9.0.0/24       # a management VLAN reached over a VPN
+  #
+  #     Extra SOURCE ranges that may reach the management services, on top of
+  #     the LAN. Every entry must be non-globally-routable - RFC1918, CGNAT,
+  #     link-local or loopback - so no entry can ever name an internet source.
+  #     Entries are also checked against the addresses actually on your uplinks
+  #     when applying: a private range that happens to BE your WAN (a double-NAT
+  #     uplink on 192.168.4.0/22, say) is dropped and reported.
+  #
+  #   cleartext: true
+  #     Keep telnet and ftp enabled. They stay bound to the LAN like everything
+  #     else, so this is a LAN-sniffing decision, not a WAN one. Default is to
+  #     disable them: both send the password in clear, and this tool drives
+  #     devices over SSH.
+  #
+  # LOCKOUT SAFETY. Before restricting anything, the tool asks the DEVICE which
+  # sessions are connected to it (`/user active print terse`) and skips the
+  # whole restriction unless every one of them is covered. Being unable to tell
+  # counts as not covered. So applying from a jump host, a VPN, or over the WAN
+  # address leaves the services open and says so loudly - the firewall rule
+  # still keeps the uplinks closed - rather than locking you out of a remote
+  # gateway. Re-apply from the LAN, or add your range to `allow`, and it lands.
+  #
+  # Note that changing lan.address means run one is made from the OLD subnet,
+  # so the restriction is skipped; run two, from the new address, applies it.
+
   # TCP MSS clamping, on by default. An uplink narrower than 1500 bytes - PPPoE
   # at 1492, most LTE bearers - needs each end told how much it may send. The
   # normal way to learn that is path MTU discovery, which relies on an ICMP

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1551,7 +1551,9 @@ test('omitting mssClamp is valid and leaves it on', () => {
       exec: async cmd => {
         sent.push(cmd);
         if (opts.fail && opts.fail(cmd)) throw new Error('permission denied');
-        if (/^\/interface list member print/.test(cmd)) return MEMBER_TERSE;
+        if (/^\/interface list member print/.test(cmd)) {
+          return opts.members !== undefined ? opts.members : MEMBER_TERSE;
+        }
         if (/^\/ip address print terse/.test(cmd)) {
           // '' models uplinks that are up but have no address yet - the case
           // where an allow entry cannot be proven safe.
@@ -1776,13 +1778,19 @@ test('omitting mssClamp is valid and leaves it on', () => {
     const seenIfaces = [];
     const dev = mgmtDevice({
       sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full',
+      // A pppoe-only router: the WAN list holds the parent, and the address is
+      // on the client interface.
+      members: '6 comment=wan:fibre type=pppoe list=WAN interface=ether1 dynamic=no',
       wanAddresses: '0 address=203.0.113.9/32 interface=pppoe-fibre actual-interface=pppoe-fibre'
     });
     return readWanAddresses(dev, pppoeWans).then(res => {
       seenIfaces.push(...res.addresses);
-      assert.deepStrictEqual(res.unresolved.filter(i => i === 'pppoe-fibre'), [],
-        'pppoe-fibre must be recognised as resolved once it has an address');
       assert.ok(res.addresses.includes('203.0.113.9/32'), JSON.stringify(res));
+      // The REAL assertion: nothing is left unresolved. The parent ether1 never
+      // carries an address on a pppoe setup, so if it stayed in the watch set
+      // this router could never be hardened at all.
+      assert.deepStrictEqual(res.unresolved, [],
+        `the pppoe parent must not linger as unresolved: ${JSON.stringify(res)}`);
     });
   });
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1008,6 +1008,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
         sent.push(cmd);
         if (cmd.includes('master-interface')) {
           if (opts.masterLookupThrows) throw new Error('no such item');
+          if (opts.masterValue !== undefined) return opts.masterValue;
           return opts.isMaster ? '' : 'wifi2';
         }
         if (cmd.includes('running')) {
@@ -1039,6 +1040,16 @@ test('omitting mssClamp is valid and leaves it on', () => {
   test('an interface that is already running is left alone', () => {
     assert.strictEqual(upFirstProblem, null);
     assert.strictEqual(toggles(upFirstTry).length, 0, 'must not bounce a working interface');
+  });
+
+  const garbled = wifiDevice(99, { masterValue: 'invalid value for argument something' });
+  const garbledProblem = await ensureWifiInterfaceUp(garbled, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  test('a garbled classification answer is NOT read as "virtual"', () => {
+    // Believing junk here means bouncing a MASTER radio and cutting every
+    // client, possibly including the operator's own link. Require an
+    // interface-name shape, not merely non-empty text.
+    assert.strictEqual(toggles(garbled).length, 0, 'must not toggle on an unrecognised answer');
+    assert.ok(garbledProblem, 'and must not call it healthy either');
   });
 
   const upAfterRetry = wifiDevice(2);
@@ -1465,13 +1476,31 @@ test('omitting mssClamp is valid and leaves it on', () => {
     // Captured from the live Chateau LTE6. Note `when=` carries a space, which
     // a naive whitespace split would turn into a bogus field.
     const real = '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full';
-    assert.deepStrictEqual(activeSessionAddresses(real), [{ address: '192.168.80.199', via: 'ssh' }]);
+    const { sessions, unreadable } = activeSessionAddresses(real);
+    assert.deepStrictEqual(sessions, [{ address: '192.168.80.199', via: 'ssh' }]);
+    assert.deepStrictEqual(unreadable, []);
   });
 
   test('a console session is ignored - no IP restriction can affect it', () => {
     const out = '0 when=2026-08-27 19:44:13 name=admin via=local group=full\n'
       + '1 when=2026-08-27 19:45:00 name=admin address=192.168.80.5 via=winbox group=full';
-    assert.deepStrictEqual(activeSessionAddresses(out), [{ address: '192.168.80.5', via: 'winbox' }]);
+    const { sessions, unreadable } = activeSessionAddresses(out);
+    assert.deepStrictEqual(sessions, [{ address: '192.168.80.5', via: 'winbox' }]);
+    assert.deepStrictEqual(unreadable, [], 'a console session is safe to disregard, not unreadable');
+  });
+
+  test('a session we CANNOT parse is surfaced, never silently dropped', () => {
+    // The old code skipped these. A parseable session elsewhere then made the
+    // guard pass while an unreadable one - possibly this very connection - was
+    // never checked against the restriction.
+    const out = '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full\n'
+      + '1 when=2026-08-27 19:45:00 name=admin address=fe80::1%ether1 via=winbox group=full\n'
+      + '2 when=2026-08-27 19:46:00 name=admin via=api group=full';
+    const { sessions, unreadable } = activeSessionAddresses(out);
+    assert.deepStrictEqual(sessions, [{ address: '192.168.80.199', via: 'ssh' }]);
+    assert.strictEqual(unreadable.length, 2,
+      'an IPv6 peer and an address-less session must both count as unreadable');
+    assert.ok(unreadable.every(u => u.raw), 'the raw record is kept so a human can see what it was');
   });
 
   console.log('\n=== Management plane: applying the restriction ===');
@@ -1523,7 +1552,11 @@ test('omitting mssClamp is valid and leaves it on', () => {
         sent.push(cmd);
         if (opts.fail && opts.fail(cmd)) throw new Error('permission denied');
         if (/^\/interface list member print/.test(cmd)) return MEMBER_TERSE;
-        if (/^\/ip address print terse/.test(cmd)) return ADDRESS_TERSE;
+        if (/^\/ip address print terse/.test(cmd)) {
+          // '' models uplinks that are up but have no address yet - the case
+          // where an allow entry cannot be proven safe.
+          return opts.wanAddresses !== undefined ? opts.wanAddresses : ADDRESS_TERSE;
+        }
         if (/^\/ip service print terse/.test(cmd)) return SERVICE_TERSE;
         if (/^\/user active print terse/.test(cmd)) {
           if (opts.sessionsThrow) throw new Error('timeout');
@@ -1702,12 +1735,34 @@ test('omitting mssClamp is valid and leaves it on', () => {
     sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full'
   });
   const wideProblems = await configureManagementServices(wide, wideLan, MGMT_WANS, true);
-  test('a LAN wide enough to swallow the WAN is reported, and still restricted', () => {
-    // 192.168.0.0/16 contains the 192.168.4.24 WAN address. Dropping it would
-    // leave an empty list, which means no restriction at all - strictly worse.
-    // So it is applied and loudly reported; the firewall rule covers the gap.
+  test('a LAN wide enough to swallow the WAN binds NOTHING', () => {
+    // 192.168.0.0/16 contains the 192.168.4.24 uplink address. Binding to it
+    // would install an allow-list that ADMITS the WAN while reporting that
+    // management was locked to the LAN. Claiming a protection we are not
+    // providing is worse than not providing it, so nothing is bound and the
+    // firewall rule stays the honest single layer it already was.
     assert.ok(wideProblems.some(p => /Renumber the LAN/.test(p)), wideProblems.join('; '));
-    assert.strictEqual(wide.address.get('ssh'), '192.168.0.0/16');
+    assert.strictEqual(wide.address.get('ssh'), '',
+      'must not bind an allow-list that contains the uplink');
+  });
+
+  test('an allow entry is dropped when an uplink has no address yet', () => {
+    // A private range proves nothing - this device's own WAN is RFC1918. The
+    // only real check is against the address actually on the uplink, and a
+    // DHCP or LTE uplink can acquire one inside an allowed range moments later.
+    const pending = mgmtDevice({
+      sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full',
+      wanAddresses: ''   // uplinks up, no addresses yet
+    });
+    return configureManagementServices(
+      pending,
+      { address: '192.168.80.1/24', management: { allow: ['10.9.0.0/16'] } },
+      MGMT_WANS, true
+    ).then(probs => {
+      assert.ok(probs.some(p => /lan\.management\.allow was ignored/.test(p)), probs.join('; '));
+      assert.strictEqual(pending.address.get('ssh'), '192.168.80.0/24',
+        'the LAN still binds; only the unprovable extra range is dropped');
+    });
   });
 
   console.log('\n=== Management plane: verification and self-heal ===');
@@ -1758,10 +1813,28 @@ test('omitting mssClamp is valid and leaves it on', () => {
 
   const setFails = mgmtDevice({ fail: cmd => /name="winbox"\] address=/.test(cmd) });
   const setFailProblems = await configureManagementServices(setFails, LAN, MGMT_WANS, true);
-  test('a service that cannot be bound is reported, and the rest still are', () => {
+  test('a failed bind ABORTS and rolls everything back', () => {
+    // The old behaviour was to report it and keep going. That leaves a device
+    // half-restricted: if the failure lands before ssh, every alternative
+    // recovery path is bound while the lifeline is not. A partial management
+    // restriction is worse than none, so the run is undone.
     assert.ok(setFailProblems.some(p => /Could not bind the winbox service/.test(p)),
       setFailProblems.join('; '));
-    assert.strictEqual(setFails.address.get('ssh'), '192.168.80.0/24', 'one failure must not abort the rest');
+    assert.strictEqual(setFails.address.get('ssh'), '',
+      'ssh must NOT be left bound after an aborted run');
+    for (const [name, value] of setFails.address) {
+      assert.strictEqual(value, '', `${name} should have been rolled back, got '${value}'`);
+    }
+  });
+
+  test('rollback restores what was there before, not just empty', () => {
+    // A device that already had a restriction must get THAT back, not blanked.
+    const preset = mgmtDevice({ fail: cmd => /name="winbox"\] address=/.test(cmd) });
+    preset.address.set('ssh', '10.5.0.0/16');
+    return configureManagementServices(preset, LAN, MGMT_WANS, true).then(() => {
+      assert.strictEqual(preset.address.get('ssh'), '10.5.0.0/16',
+        'the prior value must be restored, not cleared');
+    });
   });
 
   const l2Fails = mgmtDevice({ fail: cmd => /mac-server mac-winbox set/.test(cmd) });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1794,6 +1794,27 @@ test('omitting mssClamp is valid and leaves it on', () => {
     });
   });
 
+  test('an address ON the pppoe parent is still checked for overlap', () => {
+    // The parent does not have to resolve, but it CAN carry an address - DHCP
+    // for reaching the upstream modem is common - and that address is on the
+    // WAN side just the same. Dropping the parent entirely would have made it
+    // invisible to the overlap check.
+    const dev = mgmtDevice({
+      sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full',
+      members: '6 comment=wan:fibre type=pppoe list=WAN interface=ether1 dynamic=no',
+      wanAddresses: [
+        '0 address=203.0.113.9/32 interface=pppoe-fibre actual-interface=pppoe-fibre',
+        '1 address=192.168.100.2/24 interface=ether1 actual-interface=ether1'
+      ].join('\n')
+    });
+    return readWanAddresses(dev, [{ name: 'fibre', interface: 'ether1', type: 'pppoe' }]).then(res => {
+      assert.ok(res.addresses.includes('192.168.100.2/24'),
+        `the parent's own address must be checked: ${JSON.stringify(res)}`);
+      assert.deepStrictEqual(res.unresolved, [],
+        'but the parent must never be REQUIRED to have one');
+    });
+  });
+
   console.log('\n=== Management plane: verification and self-heal ===');
 
   const drifted = mgmtDevice({ corrupt: (name, value) => (name === 'www' ? '' : value) });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -14,13 +14,14 @@ const {
   parseCidr, cidrContains, networkOf, defaultPoolFor,
   normalizeWans, wanMemberComment, parseWanMemberComment,
   resolveHostAddress, configureMssClamp, mssClampRuleIsCurrent, terseRecords,
-  parseTerseRecord
+  parseTerseRecord, configureManagementServices, managementAllowList,
+  activeSessionAddresses, parseAddressList, backupRouterConfig
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
 const { MikroTikSSH, redactSecrets } = require('../lib/ssh-client');
 const { EventEmitter } = require('events');
 const {
-  ensureWifiInterfaceUp, recheckPendingMasters, runningQuery
+  ensureWifiInterfaceUp, recheckPendingMasters, runningQuery, pollUntilRunning
 } = require('../lib/wifi-config');
 const { validateRouterConfig } = require('../lib/validate-router');
 
@@ -1020,18 +1021,28 @@ test('omitting mssClamp is valid and leaves it on', () => {
       }
     };
   };
-  const noSleep = { sleep: async () => {}, delayMs: 0 };
+  // A fake clock. Nothing waits in real time, but the settle budget still
+  // expires, so a test that exhausts it does so deterministically instead of
+  // relying on the round cap to bail it out.
+  const fakeClock = () => {
+    let t = 0;
+    return { now: () => t, sleep: async ms => { t += ms; }, elapsed: () => t };
+  };
+  const noSleep = () => {
+    const clock = fakeClock();
+    return { sleep: clock.sleep, now: clock.now, clock };
+  };
   const toggles = d => d.sent.filter(c => c.includes('disabled='));
 
   const upFirstTry = wifiDevice(1);
-  const upFirstProblem = await ensureWifiInterfaceUp(upFirstTry, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  const upFirstProblem = await ensureWifiInterfaceUp(upFirstTry, '/interface/wifi', 'wifi2-ssid2', noSleep());
   test('an interface that is already running is left alone', () => {
     assert.strictEqual(upFirstProblem, null);
     assert.strictEqual(toggles(upFirstTry).length, 0, 'must not bounce a working interface');
   });
 
   const upAfterRetry = wifiDevice(2);
-  const retryProblem = await ensureWifiInterfaceUp(upAfterRetry, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  const retryProblem = await ensureWifiInterfaceUp(upAfterRetry, '/interface/wifi', 'wifi2-ssid2', noSleep());
   test('a virtual AP that failed to create is retried and comes up', () => {
     assert.strictEqual(retryProblem, null, `expected recovery, got: ${retryProblem}`);
     assert.deepStrictEqual(
@@ -1047,7 +1058,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
   // A master also has benign reasons to read not-running: DFS channel
   // availability check, a CAP still provisioning, CAPsMAN not done activating.
   const masterDown = wifiDevice(99, { isMaster: true });
-  const masterProblem = await ensureWifiInterfaceUp(masterDown, '/interface/wifi', 'wifi2', noSleep);
+  const masterProblem = await ensureWifiInterfaceUp(masterDown, '/interface/wifi', 'wifi2', noSleep());
   test('a MASTER radio that is not running is NEVER bounced', () => {
     assert.strictEqual(toggles(masterDown).length, 0,
       `must not touch a master radio, sent: ${JSON.stringify(toggles(masterDown))}`);
@@ -1059,7 +1070,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
     const pendingMasters = [];
     const deferred = wifiDevice(99, { isMaster: true });
     const problem = await ensureWifiInterfaceUp(deferred, '/interface/wifi', 'wifi2',
-      { ...noSleep, pendingMasters });
+      { ...noSleep(), pendingMasters });
     assert.strictEqual(problem, null, 'deferred, so not an immediate failure');
     assert.deepStrictEqual(pendingMasters, ['wifi2'], 'must be queued for re-check');
     assert.strictEqual(toggles(deferred).length, 0, 'still must not bounce it');
@@ -1067,7 +1078,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
 
   test('a not-running master with nowhere to defer is reported, not passed', async () => {
     const orphan = wifiDevice(99, { isMaster: true });
-    const problem = await ensureWifiInterfaceUp(orphan, '/interface/wifi', 'wifi2', noSleep);
+    const problem = await ensureWifiInterfaceUp(orphan, '/interface/wifi', 'wifi2', noSleep());
     assert.ok(problem, 'must not report a dead master as healthy');
     assert.ok(/not running/i.test(problem), problem);
     assert.strictEqual(toggles(orphan).length, 0, 'still must not bounce it');
@@ -1075,7 +1086,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
 
   const neverUp = wifiDevice(99);
   const neverProblem = await ensureWifiInterfaceUp(neverUp, '/interface/wifi', 'wifi2-ssid2',
-    { ...noSleep, attempts: 3 });
+    { ...noSleep(), attempts: 3 });
   test('a virtual AP that never comes up is reported, not passed', () => {
     assert.ok(neverProblem, 'a dead SSID must produce a problem');
     assert.ok(/not running/i.test(neverProblem), neverProblem);
@@ -1089,7 +1100,7 @@ test('omitting mssClamp is valid and leaves it on', () => {
   });
 
   const unreadable = wifiDevice(1, { readThrows: true });
-  const unreadableProblem = await ensureWifiInterfaceUp(unreadable, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  const unreadableProblem = await ensureWifiInterfaceUp(unreadable, '/interface/wifi', 'wifi2-ssid2', noSleep());
   test('an unreadable interface is reported without blind retries', () => {
     assert.ok(unreadableProblem, 'must report');
     assert.ok(/could not be read back/i.test(unreadableProblem), unreadableProblem);
@@ -1098,9 +1109,113 @@ test('omitting mssClamp is valid and leaves it on', () => {
   });
 
   const stuck = wifiDevice(99, { toggleThrows: true });
-  const stuckProblem = await ensureWifiInterfaceUp(stuck, '/interface/wifi', 'wifi2-ssid2', noSleep);
+  const stuckProblem = await ensureWifiInterfaceUp(stuck, '/interface/wifi', 'wifi2-ssid2', noSleep());
   test('a failed restart is reported rather than swallowed', () => {
     assert.ok(/could not be restarted/i.test(stuckProblem), stuckProblem);
+  });
+
+
+  console.log('\n=== VAP settle budget (the 6.2.3 false negative) ===');
+
+  // THE REGRESSION. 6.2.3 waited a flat 3s after each toggle and gave up after
+  // two of them. On the live Chateau the apply exhausted that, reported the
+  // SSID dead and exited INCOMPLETE - and the interface came up moments later.
+  // A false negative on a healthy device breaks any automation gating on the
+  // exit code, so it fails in the worse direction.
+  const lateRecovery = wifiDevice(5);
+  const lateOpts = noSleep();
+  const lateProblem = await ensureWifiInterfaceUp(
+    lateRecovery, '/interface/wifi', 'wifi2-ssid2', lateOpts);
+  test('a VAP that comes up well after the toggle is NOT reported dead', () => {
+    assert.strictEqual(lateProblem, null,
+      `a late but real recovery must pass, got: ${lateProblem}`);
+  });
+  test('waiting longer does not mean toggling more - one toggle, then patience', () => {
+    // Re-toggling mid-recovery would restart the very thing being waited for.
+    assert.deepStrictEqual(
+      toggles(lateRecovery).map(c => /disabled=(\w+)/.exec(c)[1]), ['yes', 'no'],
+      'exactly one disable/enable, then poll');
+  });
+  test('the settle wait is a POLL, not one long sleep', () => {
+    // Several reads after the single toggle is what makes an early recovery
+    // return early instead of always paying the whole budget.
+    const reads = lateRecovery.sent.filter(c => c.includes('running')).length;
+    assert.ok(reads >= 3, `expected repeated reads while settling, got ${reads}`);
+  });
+
+  const healthy = wifiDevice(1);
+  const healthyOpts = noSleep();
+  await ensureWifiInterfaceUp(healthy, '/interface/wifi', 'wifi2-ssid2', healthyOpts);
+  test('a healthy interface pays none of the budget', () => {
+    // Polling is only free if the common case never enters the poll.
+    assert.strictEqual(healthyOpts.clock.elapsed(), 0, 'no time may pass for an up interface');
+    assert.strictEqual(healthy.sent.filter(c => c.includes('running')).length, 1,
+      'one read, not a poll cycle');
+  });
+
+  const exhausted = wifiDevice(999);
+  const exhaustedOpts = noSleep();
+  const exhaustedProblem = await ensureWifiInterfaceUp(
+    exhausted, '/interface/wifi', 'wifi2-ssid2', exhaustedOpts);
+  test('a budget that genuinely expires STILL reports the problem', () => {
+    // The honest failure is the good part of 6.2.3 and must not regress into
+    // "wait longer and then claim success".
+    assert.ok(exhaustedProblem, 'a dead SSID must still produce a problem');
+    assert.ok(/not running/i.test(exhaustedProblem), exhaustedProblem);
+    assert.ok(/failed to create interface/.test(exhaustedProblem),
+      `the device's own reason must survive: ${exhaustedProblem}`);
+  });
+  test('the budget is bounded, and is 60s by default', () => {
+    const spent = exhaustedOpts.clock.elapsed();
+    assert.ok(spent > 6000, `6.2.3 spent about 6s; this must be far more, got ${spent}ms`);
+    // Two toggles at 500ms each on top of the 60s of settling.
+    assert.ok(spent <= 62000, `must stay bounded, got ${spent}ms`);
+  });
+
+  const manyAttempts = wifiDevice(999);
+  const manyOpts = { ...noSleep(), attempts: 6 };
+  await ensureWifiInterfaceUp(manyAttempts, '/interface/wifi', 'wifi2-ssid2', manyOpts);
+  test('the budget is SHARED across retries, so more attempts cost no more time', () => {
+    // A per-retry budget would make attempts=6 wait five minutes. The retries
+    // divide the budget instead of multiplying it.
+    assert.strictEqual(toggles(manyAttempts).length, 10, 'five retries, disable+enable each');
+    assert.ok(manyOpts.clock.elapsed() <= 63000,
+      `raising attempts must not multiply the wait, got ${manyOpts.clock.elapsed()}ms`);
+  });
+
+  const masterPatience = wifiDevice(999, { isMaster: true });
+  const masterOpts = noSleep();
+  await ensureWifiInterfaceUp(masterPatience, '/interface/wifi', 'wifi2', masterOpts);
+  test('the longer budget did NOT loosen the master-radio safety property', () => {
+    // The master carries every associated client, very possibly including the
+    // operator running this tool over that radio.
+    assert.strictEqual(toggles(masterPatience).length, 0,
+      `a master must never be toggled, sent: ${JSON.stringify(toggles(masterPatience))}`);
+    assert.strictEqual(masterOpts.clock.elapsed(), 0, 'and it must not sit in the poll either');
+  });
+
+  test('the settle poll reads through the same :put-wrapped query', () => {
+    // pollUntilRunning is now shared with recheckPendingMasters, so a bare get
+    // here would break both. A bare get prints nothing over an SSH exec.
+    for (const cmd of lateRecovery.sent.filter(c => c.includes('running'))) {
+      assert.ok(cmd.startsWith(':put ['), `a bare get reads back empty: ${cmd}`);
+    }
+  });
+
+  // The shared primitive, exercised directly. Awaited OUT HERE: test() does not
+  // await its callback, so an async body would be counted as a pass whatever
+  // it asserted.
+  let pollT = 0;
+  const pollDevice = {
+    sent: [],
+    exec: async c => { pollDevice.sent.push(c); pollT += 1000; return 'false'; }
+  };
+  const pollResult = await pollUntilRunning(pollDevice, ['wifi1', 'wifi1', 'wifi2'], {
+    timeoutMs: 10000, pollMs: 2000, now: () => pollT, sleep: async ms => { pollT += ms; }
+  });
+  test('pollUntilRunning returns the names still down, and stops at the deadline', () => {
+    assert.deepStrictEqual([...pollResult.pending.keys()], ['wifi1', 'wifi2'], 'duplicates collapse');
+    assert.ok(pollResult.elapsedMs >= 10000, `must use the budget, got ${pollResult.elapsedMs}`);
   });
 
   console.log('\n=== Deferred master re-check ===');
@@ -1252,6 +1367,521 @@ test('omitting mssClamp is valid and leaves it on', () => {
     const d = recheckDevice([]);
     assert.deepStrictEqual(await recheckPendingMasters(d, [], fastPoll()), []);
     assert.strictEqual(d.sent.length, 0, 'must not talk to the device for an empty list');
+  });
+
+  console.log('\n=== Management plane: allow list ===');
+
+  test('the LAN network leads the allow list, masked to all-zero host bits', () => {
+    // RouterOS rejects address= outright when a host bit is set:
+    // "value of address must have all host bits zero, as in 192.168.80.0/24".
+    // Verified on RouterOS 7.18.2.
+    const { entries, problems } = managementAllowList({ address: '192.168.80.1/24' });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24']);
+    assert.deepStrictEqual(problems, []);
+  });
+
+  test('an extra allow entry is masked too, so a host address still applies', () => {
+    const { entries } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['10.9.0.5/24'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24', '10.9.0.0/24']);
+  });
+
+  test('a publicly routable allow entry is REFUSED, not applied', () => {
+    // The whole point of the feature: no config a user writes may open the
+    // management plane to an internet source.
+    const { entries, problems } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['8.8.8.0/24'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24'], 'the entry must not survive');
+    assert.ok(problems.some(p => /publicly routable/.test(p)), problems.join('; '));
+  });
+
+  test('0.0.0.0/0 cannot be smuggled in as an allow entry', () => {
+    const { entries, problems } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['0.0.0.0/0'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24']);
+    assert.ok(problems.length === 1, problems.join('; '));
+  });
+
+  test('a private-looking host address with a huge range is judged on its NETWORK', () => {
+    // 10.0.0.1/1 masks to 0.0.0.0/1, which is half the internet. Testing the
+    // address rather than the network would have waved it through.
+    const { entries, problems } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['10.0.0.1/1'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24']);
+    assert.ok(problems.some(p => /publicly routable/.test(p)), problems.join('; '));
+  });
+
+  test('CGNAT is allowed, because that is where overlay networks live', () => {
+    // Tailscale and most WireGuard overlays sit in 100.64.0.0/10. Refusing it
+    // would leave no way to manage a router across a VPN.
+    const { entries, problems } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['100.64.0.0/10'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24', '100.64.0.0/10']);
+    assert.deepStrictEqual(problems, []);
+  });
+
+  test('a malformed allow entry is reported, not silently dropped', () => {
+    const { problems } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['not-a-cidr'] }
+    });
+    assert.ok(problems.some(p => /not valid CIDR/.test(p)), problems.join('; '));
+  });
+
+  test('the LAN network is not duplicated when it is also listed explicitly', () => {
+    const { entries } = managementAllowList({
+      address: '192.168.80.1/24',
+      management: { allow: ['192.168.80.0/24'] }
+    });
+    assert.deepStrictEqual(entries, ['192.168.80.0/24']);
+  });
+
+  console.log('\n=== Management plane: RouterOS output shapes ===');
+
+  test('an address list is parsed in BOTH forms RouterOS prints', () => {
+    // Captured live: `print terse` renders the list comma-separated, while
+    // `:put [... get address]` renders the same list semicolon-separated
+    // because :put formats an array. Handling only one reads a two-entry list
+    // as one malformed entry.
+    assert.deepStrictEqual(parseAddressList('192.168.80.0/24;100.64.0.0/10'),
+      ['192.168.80.0/24', '100.64.0.0/10']);
+    assert.deepStrictEqual(parseAddressList('192.168.80.0/24,100.64.0.0/10'),
+      ['192.168.80.0/24', '100.64.0.0/10']);
+    assert.deepStrictEqual(parseAddressList(''), []);
+    assert.deepStrictEqual(parseAddressList('\r\n'), []);
+  });
+
+  test('active sessions are read from real terse output', () => {
+    // Captured from the live Chateau LTE6. Note `when=` carries a space, which
+    // a naive whitespace split would turn into a bogus field.
+    const real = '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full';
+    assert.deepStrictEqual(activeSessionAddresses(real), [{ address: '192.168.80.199', via: 'ssh' }]);
+  });
+
+  test('a console session is ignored - no IP restriction can affect it', () => {
+    const out = '0 when=2026-08-27 19:44:13 name=admin via=local group=full\n'
+      + '1 when=2026-08-27 19:45:00 name=admin address=192.168.80.5 via=winbox group=full';
+    assert.deepStrictEqual(activeSessionAddresses(out), [{ address: '192.168.80.5', via: 'winbox' }]);
+  });
+
+  console.log('\n=== Management plane: applying the restriction ===');
+
+  // Real /ip service output from the Chateau LTE6, before any change.
+  const SERVICE_TERSE = [
+    '0   name=telnet port=23 address= vrf=main max-sessions=20',
+    '1   name=ftp port=21 address= vrf=main max-sessions=20',
+    '2   name=www port=80 address= vrf=main max-sessions=20',
+    '3   name=ssh port=22 address= vrf=main max-sessions=20',
+    '4 X name=www-ssl port=443 address= certificate=none tls-version=any vrf=main max-sessions=20',
+    '5   name=api port=8728 address= vrf=main max-sessions=20',
+    '6   name=winbox port=8291 address= vrf=main max-sessions=20',
+    '7   name=api-ssl port=8729 address= certificate=none tls-version=any vrf=main max-sessions=20'
+  ].join('\n');
+  const SERVICE_NAMES = ['telnet', 'ftp', 'www', 'ssh', 'www-ssl', 'api', 'winbox', 'api-ssl'];
+
+  // Real /ip address output. ether1 is on 192.168.4.0/22 - a PRIVATE WAN behind
+  // someone else's router - and lte1 holds a public /32.
+  const ADDRESS_TERSE = [
+    '0   comment=router:lan address=192.168.80.1/24 network=192.168.80.0 interface=bridge actual-interface=bridge',
+    '1 D address=26.178.199.111/32 network=26.178.199.111 interface=lte1 actual-interface=lte1',
+    '2 D address=192.168.4.24/22 network=192.168.4.0 interface=ether1 actual-interface=ether1'
+  ].join('\n');
+
+  const MEMBER_TERSE = [
+    '6 comment=wan:primary type=dhcp distance=1 probe=8.8.8.8 list=WAN interface=ether1 dynamic=no',
+    '7 comment=wan:backup type=lte distance=2 probe=1.1.1.1 apn=fast.t-mobile.com list=WAN interface=lte1 dynamic=no'
+  ].join('\n');
+
+  const MGMT_WANS = [
+    { name: 'primary', interface: 'ether1' },
+    { name: 'backup', interface: 'lte1' }
+  ];
+
+  /**
+   * A device that actually holds state, so a `set` followed by the verifying
+   * read agrees with itself. A fake that answers whatever it is asked cannot
+   * catch a wrong command - that is exactly how v6.2.2 shipped broken.
+   */
+  const mgmtDevice = (opts = {}) => {
+    const address = new Map(SERVICE_NAMES.map(n => [n, '']));
+    const disabled = new Map(SERVICE_NAMES.map(n => [n, n === 'www-ssl']));
+    const l2 = { mac: 'all', winbox: 'all', neighbor: 'all' };
+    const sent = [];
+    const d = {
+      sent, address, disabled, l2,
+      exec: async cmd => {
+        sent.push(cmd);
+        if (opts.fail && opts.fail(cmd)) throw new Error('permission denied');
+        if (/^\/interface list member print/.test(cmd)) return MEMBER_TERSE;
+        if (/^\/ip address print terse/.test(cmd)) return ADDRESS_TERSE;
+        if (/^\/ip service print terse/.test(cmd)) return SERVICE_TERSE;
+        if (/^\/user active print terse/.test(cmd)) {
+          if (opts.sessionsThrow) throw new Error('timeout');
+          return opts.sessions !== undefined ? opts.sessions
+            : '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full';
+        }
+
+        let m = /^\/ip service set \[find name="([^"]+)"\] address="([^"]*)"$/.exec(cmd);
+        if (m) {
+          // RouterOS refuses a value with any host bit set. Model that, or the
+          // fake would accept a command the device rejects.
+          for (const entry of m[2].split(',').filter(Boolean)) {
+            if (networkOf(entry) !== entry) throw new Error('value of address must have all host bits zero');
+          }
+          // A corrupting device mangles what it is told to STORE. Applying that
+          // to the self-heal's `address=""` too would model a device that
+          // cannot be cleared, which is the separate `fail` case below.
+          address.set(m[1], opts.corrupt && m[2] ? opts.corrupt(m[1], m[2]) : m[2]);
+          return '';
+        }
+        m = /^\/ip service set \[find name="([^"]+)"\] disabled=yes$/.exec(cmd);
+        if (m) { disabled.set(m[1], true); return ''; }
+
+        m = /^:put \[\/ip service get \[find name="([^"]+)"\] address\]$/.exec(cmd);
+        if (m) return `${(address.get(m[1]) || '').split(',').join(';')}\n`;
+        m = /^:put \[\/ip service get \[find name="([^"]+)"\] disabled\]$/.exec(cmd);
+        if (m) return `${disabled.get(m[1]) ? 'true' : 'false'}\n`;
+
+        if (/^\/tool mac-server mac-winbox set /.test(cmd)) { l2.winbox = /=(\S+)$/.exec(cmd)[1]; return ''; }
+        if (/^\/tool mac-server set /.test(cmd)) { l2.mac = /=(\S+)$/.exec(cmd)[1]; return ''; }
+        if (/^\/ip neighbor discovery-settings set /.test(cmd)) { l2.neighbor = /=(\S+)$/.exec(cmd)[1]; return ''; }
+        if (/mac-server mac-winbox get/.test(cmd)) return `${l2.winbox}\n`;
+        if (/mac-server get/.test(cmd)) return `${l2.mac}\n`;
+        if (/discovery-settings get/.test(cmd)) return `${l2.neighbor}\n`;
+        if (/romon get enabled/.test(cmd)) return `${opts.romon || 'false'}\n`;
+        return '';
+      }
+    };
+    return d;
+  };
+  const LAN = { address: '192.168.80.1/24' };
+  const setsOf = d => d.sent.filter(c => /^\/ip service set /.test(c));
+
+  const boundDev = mgmtDevice();
+  const boundProblems = await configureManagementServices(boundDev, LAN, MGMT_WANS, true);
+  test('every service is bound to the LAN network, disabled ones included', () => {
+    assert.deepStrictEqual(boundProblems, [], boundProblems.join('; '));
+    for (const name of SERVICE_NAMES) {
+      assert.strictEqual(boundDev.address.get(name), '192.168.80.0/24', `${name} was left unrestricted`);
+    }
+  });
+  test('a DISABLED service is bound too, so re-enabling it cannot reopen the WAN', () => {
+    // www-ssl ships disabled. Binding only what is enabled would leave a
+    // one-command path back to an exposed management plane.
+    assert.strictEqual(boundDev.disabled.get('www-ssl'), true, 'fixture check');
+    assert.strictEqual(boundDev.address.get('www-ssl'), '192.168.80.0/24');
+  });
+  test('the cleartext services are disabled', () => {
+    assert.strictEqual(boundDev.disabled.get('telnet'), true);
+    assert.strictEqual(boundDev.disabled.get('ftp'), true);
+    assert.strictEqual(boundDev.disabled.get('www'), false, 'only telnet and ftp');
+  });
+  test('ssh is bound LAST, after every other service proved the command shape', () => {
+    const order = setsOf(boundDev).filter(c => /address=/.test(c)).map(c => /name="([^"]+)"/.exec(c)[1]);
+    assert.strictEqual(order[order.length - 1], 'ssh', `ssh must be last, got ${order.join(',')}`);
+    assert.strictEqual(new Set(order).size, SERVICE_NAMES.length, 'every service exactly once');
+  });
+  test('layer-2 management is scoped to the LAN interface list', () => {
+    // MAC-telnet and MAC-winbox run over ethernet frames. They ignore
+    // /ip service address= AND the firewall input chain, so binding IP
+    // services alone would leave the whole admin surface reachable from the
+    // WAN broadcast domain.
+    assert.deepStrictEqual(boundDev.l2, { mac: 'LAN', winbox: 'LAN', neighbor: 'LAN' });
+  });
+  test('every device read this module sends is :put-wrapped', () => {
+    // A bare `get [find ...]` prints NOTHING over an SSH exec, so every
+    // verification read would come back empty and pass or fail at random.
+    const reads = boundDev.sent.filter(c => /\bget \[?find|\bget allowed-|\bget discover-|\bget enabled/.test(c));
+    assert.ok(reads.length > 0, 'expected some reads');
+    for (const cmd of reads) {
+      assert.ok(cmd.startsWith(':put ['), `a bare get reads back empty over SSH: ${cmd}`);
+    }
+  });
+  test('the value written has all host bits zero', () => {
+    for (const cmd of setsOf(boundDev).filter(c => /address=/.test(c))) {
+      const value = /address="([^"]*)"/.exec(cmd)[1];
+      for (const entry of value.split(',')) {
+        assert.strictEqual(networkOf(entry), entry, `RouterOS would reject ${entry}`);
+      }
+    }
+  });
+
+  console.log('\n=== Management plane: the lockout guard ===');
+
+  const offLan = mgmtDevice({
+    sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.4.77 via=ssh group=full'
+  });
+  const offLanProblems = await configureManagementServices(offLan, LAN, MGMT_WANS, true);
+  test('an operator connected from off-LAN is NEVER locked out', () => {
+    // THE primary constraint. Locking an operator out of a remote gateway is
+    // far worse than the exposure this closes, so the restriction is skipped.
+    assert.strictEqual(setsOf(offLan).length, 0, `nothing may be set, sent: ${setsOf(offLan)}`);
+    for (const name of SERVICE_NAMES) assert.strictEqual(offLan.address.get(name), '');
+  });
+  test('a skipped restriction is a warning, not a failed apply', () => {
+    // configureRouterFirewall() already skips its drop rule the same way when
+    // it cannot verify the LAN list. Failing an otherwise-good apply because a
+    // SAFETY guard fired would be its own kind of breakage.
+    assert.deepStrictEqual(offLanProblems, [], offLanProblems.join('; '));
+  });
+  test('the layer-2 scoping is skipped with it, not applied half-way', () => {
+    assert.deepStrictEqual(offLan.l2, { mac: 'all', winbox: 'all', neighbor: 'all' });
+  });
+
+  const blindSession = mgmtDevice({ sessionsThrow: true });
+  await configureManagementServices(blindSession, LAN, MGMT_WANS, true);
+  test('not being able to tell who is connected counts as "do not restrict"', () => {
+    assert.strictEqual(setsOf(blindSession).length, 0, 'must not restrict on a guess');
+  });
+
+  const noSessions = mgmtDevice({ sessions: '' });
+  await configureManagementServices(noSessions, LAN, MGMT_WANS, true);
+  test('an empty session list means the read is wrong, not that nobody is on', () => {
+    // This very session must appear in that list. An empty answer is evidence
+    // the command or the parse is broken, and restricting on it would be
+    // restricting blind.
+    assert.strictEqual(setsOf(noSessions).length, 0);
+  });
+
+  const twoSessions = mgmtDevice({
+    sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full\n'
+      + '1 when=2026-08-27 19:45:00 name=admin address=10.7.7.7 via=winbox group=full'
+  });
+  await configureManagementServices(twoSessions, LAN, MGMT_WANS, true);
+  test('ANY uncovered session blocks the restriction, not just this one', () => {
+    // There is no reliable way to tell which active session is ours, so every
+    // one of them has to survive.
+    assert.strictEqual(setsOf(twoSessions).length, 0);
+  });
+
+  const vpnLan = { address: '192.168.80.1/24', management: { allow: ['10.7.0.0/16'] } };
+  const vpn = mgmtDevice({
+    sessions: '0 when=2026-08-27 19:45:00 name=admin address=10.7.7.7 via=ssh group=full'
+  });
+  const vpnProblems = await configureManagementServices(vpn, vpnLan, MGMT_WANS, true);
+  test('an allow entry covering the operator lets the restriction land', () => {
+    assert.deepStrictEqual(vpnProblems, [], vpnProblems.join('; '));
+    assert.strictEqual(vpn.address.get('ssh'), '192.168.80.0/24,10.7.0.0/16');
+  });
+
+  console.log('\n=== Management plane: an allow entry cannot reach the WAN ===');
+
+  const wanOverlap = { address: '192.168.80.1/24', management: { allow: ['192.168.4.0/22'] } };
+  const overlap = mgmtDevice();
+  const overlapProblems = await configureManagementServices(overlap, wanOverlap, MGMT_WANS, true);
+  test('a PRIVATE allow entry that is actually the WAN subnet is dropped', () => {
+    // The test device's own ether1 sits on 192.168.4.0/22 behind another
+    // router. It passes every static "is this private" check, and it is the
+    // WAN. Only comparing against the addresses live on the uplinks catches it.
+    assert.ok(overlapProblems.some(p => /covers the uplink address 192\.168\.4\.24\/22/.test(p)),
+      overlapProblems.join('; '));
+    assert.strictEqual(overlap.address.get('ssh'), '192.168.80.0/24', 'the WAN range must not be bound');
+  });
+
+  const cgnat = mgmtDevice();
+  const cgnatWans = [{ name: 'primary', interface: 'ether1' }];
+  const cgnatProblems = await configureManagementServices(
+    cgnat, { address: '192.168.80.1/24', management: { allow: ['100.64.0.0/10'] } }, cgnatWans, true);
+  test('a CGNAT allow entry is kept when no uplink is inside it', () => {
+    assert.deepStrictEqual(cgnatProblems, [], cgnatProblems.join('; '));
+    assert.strictEqual(cgnat.address.get('ssh'), '192.168.80.0/24,100.64.0.0/10');
+  });
+
+  const wideLan = { address: '192.168.0.1/16' };
+  const wide = mgmtDevice({
+    sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full'
+  });
+  const wideProblems = await configureManagementServices(wide, wideLan, MGMT_WANS, true);
+  test('a LAN wide enough to swallow the WAN is reported, and still restricted', () => {
+    // 192.168.0.0/16 contains the 192.168.4.24 WAN address. Dropping it would
+    // leave an empty list, which means no restriction at all - strictly worse.
+    // So it is applied and loudly reported; the firewall rule covers the gap.
+    assert.ok(wideProblems.some(p => /Renumber the LAN/.test(p)), wideProblems.join('; '));
+    assert.strictEqual(wide.address.get('ssh'), '192.168.0.0/16');
+  });
+
+  console.log('\n=== Management plane: verification and self-heal ===');
+
+  const drifted = mgmtDevice({ corrupt: (name, value) => (name === 'www' ? '' : value) });
+  const driftProblems = await configureManagementServices(drifted, LAN, MGMT_WANS, true);
+  test('a service that does not read back restricted is reported', () => {
+    // "We issued the command" is not evidence. A silently-unrestricted service
+    // would otherwise pass the apply as a success.
+    assert.ok(driftProblems.some(p => /www service reads back as unrestricted/.test(p)),
+      driftProblems.join('; '));
+  });
+
+  const sshWrong = mgmtDevice({ corrupt: (name, value) => (name === 'ssh' ? '10.99.0.0/16' : value) });
+  const sshProblems = await configureManagementServices(sshWrong, LAN, MGMT_WANS, true);
+  test('an ssh restriction that excludes this session is CLEARED again', () => {
+    // RouterOS applies address= to new connections, so a wrong value does not
+    // drop the live session - the lockout only shows up on the next connect,
+    // when it is too late. Trading the exposure back for reachability is the
+    // right way round.
+    assert.strictEqual(sshWrong.address.get('ssh'), '', 'ssh must be reopened, not left excluding us');
+    assert.ok(sshProblems.some(p => /ssh service reads back/.test(p)), sshProblems.join('; '));
+  });
+  test('the self-heal still fails the apply rather than reporting success', () => {
+    assert.ok(sshProblems.length > 0);
+  });
+
+  const sshStuck = mgmtDevice({
+    corrupt: (name, value) => (name === 'ssh' ? '10.99.0.0/16' : value),
+    fail: cmd => /name="ssh"\] address=""/.test(cmd)
+  });
+  const stuckSshProblems = await configureManagementServices(sshStuck, LAN, MGMT_WANS, true);
+  test('an ssh restriction that excludes us AND cannot be cleared says URGENT', () => {
+    // The one outcome that needs a human immediately: the live session still
+    // works, and the next connect will not.
+    assert.ok(stuckSshProblems.some(p => /^URGENT/.test(p)), stuckSshProblems.join('; '));
+  });
+
+  const sshOk = mgmtDevice({
+    corrupt: (name, value) => (name === 'ssh' ? '192.168.80.0/24,10.99.0.0/16' : value)
+  });
+  await configureManagementServices(sshOk, LAN, MGMT_WANS, true);
+  test('a wrong ssh value that still covers this session is not cleared', () => {
+    // Clearing it would reopen the management plane to answer a mismatch that
+    // is not a lockout. Report it and leave the restriction standing.
+    assert.strictEqual(sshOk.address.get('ssh'), '192.168.80.0/24,10.99.0.0/16');
+  });
+
+  const setFails = mgmtDevice({ fail: cmd => /name="winbox"\] address=/.test(cmd) });
+  const setFailProblems = await configureManagementServices(setFails, LAN, MGMT_WANS, true);
+  test('a service that cannot be bound is reported, and the rest still are', () => {
+    assert.ok(setFailProblems.some(p => /Could not bind the winbox service/.test(p)),
+      setFailProblems.join('; '));
+    assert.strictEqual(setFails.address.get('ssh'), '192.168.80.0/24', 'one failure must not abort the rest');
+  });
+
+  const l2Fails = mgmtDevice({ fail: cmd => /mac-server mac-winbox set/.test(cmd) });
+  const l2Problems = await configureManagementServices(l2Fails, LAN, MGMT_WANS, true);
+  test('a layer-2 surface that cannot be scoped is reported', () => {
+    assert.ok(l2Problems.some(p => /MAC-winbox server/.test(p)), l2Problems.join('; '));
+  });
+
+  const noLanList = mgmtDevice();
+  await configureManagementServices(noLanList, LAN, MGMT_WANS, false);
+  test('layer-2 scoping waits for a verified LAN list, IP binding does not', () => {
+    // Pointing MAC-winbox at a list that does not contain the bridge would
+    // remove the recovery path that exists for exactly this kind of mistake.
+    // The IP binding is checked against the live session instead, so it is safe
+    // either way.
+    assert.deepStrictEqual(noLanList.l2, { mac: 'all', winbox: 'all', neighbor: 'all' });
+    assert.strictEqual(noLanList.address.get('ssh'), '192.168.80.0/24');
+  });
+
+  const keepCleartext = mgmtDevice();
+  await configureManagementServices(
+    keepCleartext, { address: '192.168.80.1/24', management: { cleartext: true } }, MGMT_WANS, true);
+  test('cleartext: true keeps telnet and ftp, still bound to the LAN', () => {
+    // The escape hatch may soften the cleartext default; it may not reach the
+    // WAN. Nothing in lan.management can.
+    assert.strictEqual(keepCleartext.disabled.get('telnet'), false);
+    assert.strictEqual(keepCleartext.address.get('telnet'), '192.168.80.0/24');
+  });
+
+  const noLan = mgmtDevice();
+  const noLanProblems = await configureManagementServices(noLan, {}, MGMT_WANS, true);
+  test('no lan.address means no restriction, said out loud', () => {
+    assert.strictEqual(setsOf(noLan).length, 0);
+    assert.deepStrictEqual(noLanProblems, []);
+  });
+
+  test('lib/router.js sends no bare get either', () => {
+    // The same guard test/router.test.js already applies to lib/wifi-config.js.
+    // v6.2.2 shipped `/interface get [find name=X] running` with no :put and
+    // every read came back empty.
+    const src = require('fs').readFileSync(require.resolve('../lib/router'), 'utf8');
+    const bare = src.split('\n').filter(line =>
+      /exec\(/.test(line) && /\bget (\[find|allowed-|discover-|enabled)/.test(line) && !/:put \[/.test(line));
+    assert.deepStrictEqual(bare, [],
+      `these send a bare get and will read back empty:\n${bare.join('\n')}`);
+  });
+
+  console.log('\n=== Management plane: backup round-trip ===');
+
+  // backupRouterConfig() only needs the masquerade rule to decide it is looking
+  // at a router; everything else it cannot read is simply left out.
+  const backupDevice = (services) => ({
+    exec: async cmd => {
+      if (/nat print terse/.test(cmd)) return ' 0 chain=srcnat comment="router:masquerade"';
+      if (/^\/ip service print terse/.test(cmd)) return services;
+      if (/^\/ip address print detail/.test(cmd)) {
+        return 'Flags: D - dynamic\n 0   ;;; router:lan\n     address=192.168.80.1/24 interface=bridge';
+      }
+      return '';
+    }
+  });
+
+  const restricted = await backupRouterConfig(backupDevice([
+    '0 X name=telnet port=23 address=192.168.80.0/24 vrf=main',
+    '1 X name=ftp port=21 address=192.168.80.0/24 vrf=main',
+    '3   name=ssh port=22 address=192.168.80.0/24,10.7.0.0/16 vrf=main'
+  ].join('\n')));
+  test('an extra allow range round-trips out of the device', () => {
+    assert.deepStrictEqual(restricted.lan.management, { allow: ['10.7.0.0/16'] });
+  });
+  test('the LAN network itself is not written back as an allow entry', () => {
+    // lan.address already implies it, so recording it would put a redundant
+    // line in every backup.
+    assert.ok(!restricted.lan.management.allow.includes('192.168.80.0/24'));
+  });
+
+  const keptCleartext = await backupRouterConfig(backupDevice([
+    '0   name=telnet port=23 address=192.168.80.0/24 vrf=main',
+    '3   name=ssh port=22 address=192.168.80.0/24 vrf=main'
+  ].join('\n')));
+  test('a deliberately kept cleartext service round-trips', () => {
+    assert.deepStrictEqual(keptCleartext.lan.management, { cleartext: true });
+  });
+
+  const neverHardened = await backupRouterConfig(backupDevice(SERVICE_TERSE));
+  test('an UNHARDENED device records no management block at all', () => {
+    // This is the important one. telnet is enabled here, but ssh still listens
+    // on any address, so the device has simply never been hardened. Recording
+    // `cleartext: true` off the back of that would make a backup/restore cycle
+    // silently carry "leave telnet on" forward for ever.
+    assert.strictEqual(neverHardened.lan.management, undefined);
+  });
+
+  console.log('\n=== Management plane: validation ===');
+
+  const mgmtBase = { lan: { address: '192.168.80.1/24' }, wan: [{ name: 'a', interface: 'ether1' }] };
+  const withMgmt = management => validateRouterConfig({
+    ...mgmtBase, lan: { ...mgmtBase.lan, management }
+  });
+
+  test('a public allow range is rejected by validation, before any device is touched', () => {
+    assert.ok(withMgmt({ allow: ['8.8.8.0/24'] }).errors.some(e => /publicly routable/.test(e)));
+  });
+  test('a private allow range passes, with a warning that it widens reach', () => {
+    const { errors, warnings } = withMgmt({ allow: ['10.7.0.0/16'] });
+    assert.deepStrictEqual(errors, []);
+    assert.ok(warnings.some(w => /widens management beyond the LAN/.test(w)), warnings.join('; '));
+  });
+  test('a stringy cleartext is rejected, because it is compared with === true', () => {
+    assert.ok(withMgmt({ cleartext: 'true' }).errors.some(e => /must be true or false/.test(e)));
+  });
+  test('keeping cleartext warns about the password crossing the LAN in clear', () => {
+    assert.ok(withMgmt({ cleartext: true }).warnings.some(w => /clear text/.test(w)));
+  });
+  test('lan.management must be a mapping', () => {
+    assert.ok(withMgmt(['10.0.0.0/8']).errors.some(e => /must be a mapping/.test(e)));
+    assert.ok(withMgmt({ allow: '10.0.0.0/8' }).errors.some(e => /must be a list/.test(e)));
+  });
+  test('a config with no management block is unaffected', () => {
+    assert.deepStrictEqual(validateRouterConfig(mgmtBase).errors, []);
   });
 
   console.log('\n=== SSH exec must reject RouterOS failures ===');

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -15,7 +15,7 @@ const {
   normalizeWans, wanMemberComment, parseWanMemberComment,
   resolveHostAddress, configureMssClamp, mssClampRuleIsCurrent, terseRecords,
   parseTerseRecord, configureManagementServices, managementAllowList,
-  activeSessionAddresses, parseAddressList, backupRouterConfig
+  activeSessionAddresses, parseAddressList, backupRouterConfig, readWanAddresses
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
 const { MikroTikSSH, redactSecrets } = require('../lib/ssh-client');
@@ -1746,10 +1746,12 @@ test('omitting mssClamp is valid and leaves it on', () => {
       'must not bind an allow-list that contains the uplink');
   });
 
-  test('an allow entry is dropped when an uplink has no address yet', () => {
-    // A private range proves nothing - this device's own WAN is RFC1918. The
-    // only real check is against the address actually on the uplink, and a
-    // DHCP or LTE uplink can acquire one inside an allowed range moments later.
+  test('NOTHING is bound while any uplink has no address yet', () => {
+    // A private range proves nothing - this device's own WAN is RFC1918 - so
+    // the only real check is against the address actually on the uplink. The
+    // LAN range is NOT exempt from that: if an unresolved DHCP, LTE or PPPoE
+    // uplink later takes an address inside lanNetwork, binding to that network
+    // admits the WAN exactly as an allow entry would.
     const pending = mgmtDevice({
       sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full',
       wanAddresses: ''   // uplinks up, no addresses yet
@@ -1759,9 +1761,28 @@ test('omitting mssClamp is valid and leaves it on', () => {
       { address: '192.168.80.1/24', management: { allow: ['10.9.0.0/16'] } },
       MGMT_WANS, true
     ).then(probs => {
-      assert.ok(probs.some(p => /lan\.management\.allow was ignored/.test(p)), probs.join('; '));
-      assert.strictEqual(pending.address.get('ssh'), '192.168.80.0/24',
-        'the LAN still binds; only the unprovable extra range is dropped');
+      assert.ok(probs.some(p => /left unrestricted because/.test(p)), probs.join('; '));
+      for (const [name, value] of pending.address) {
+        assert.strictEqual(value, '', `${name} must not be bound on unproven state, got '${value}'`);
+      }
+    });
+  });
+
+  test('a pppoe uplink is looked for on its CLIENT interface', () => {
+    // The address lands on pppoe-<name>, not the ethernet the config names.
+    // Without deriving it, the uplink looks addressless forever and nothing
+    // would ever bind.
+    const pppoeWans = [{ name: 'fibre', interface: 'ether1', type: 'pppoe' }];
+    const seenIfaces = [];
+    const dev = mgmtDevice({
+      sessions: '0 when=2026-08-27 19:44:13 name=admin address=192.168.80.199 via=ssh group=full',
+      wanAddresses: '0 address=203.0.113.9/32 interface=pppoe-fibre actual-interface=pppoe-fibre'
+    });
+    return readWanAddresses(dev, pppoeWans).then(res => {
+      seenIfaces.push(...res.addresses);
+      assert.deepStrictEqual(res.unresolved.filter(i => i === 'pppoe-fibre'), [],
+        'pppoe-fibre must be recognised as resolved once it has an address');
+      assert.ok(res.addresses.includes('203.0.113.9/32'), JSON.stringify(res));
     });
   });
 
@@ -1804,11 +1825,18 @@ test('omitting mssClamp is valid and leaves it on', () => {
   const sshOk = mgmtDevice({
     corrupt: (name, value) => (name === 'ssh' ? '192.168.80.0/24,10.99.0.0/16' : value)
   });
-  await configureManagementServices(sshOk, LAN, MGMT_WANS, true);
-  test('a wrong ssh value that still covers this session is not cleared', () => {
-    // Clearing it would reopen the management plane to answer a mismatch that
-    // is not a lockout. Report it and leave the restriction standing.
-    assert.strictEqual(sshOk.address.get('ssh'), '192.168.80.0/24,10.99.0.0/16');
+  const sshOkProblems = await configureManagementServices(sshOk, LAN, MGMT_WANS, true);
+  test('a wrong ssh value that still covers this session is rolled back, not cleared', () => {
+    // The device did not store what it was asked, so the run is undone like any
+    // other mismatch. The distinction that matters is that the SELF-HEAL did
+    // not fire: that path exists only for a value which would lock us out, and
+    // this one still covers this session.
+    assert.strictEqual(sshOk.address.get('ssh'), '',
+      'a mismatch aborts and rolls back, whatever the wrong value was');
+    // The distinction that still matters: this is an ordinary mismatch, not a
+    // lockout, so it must NOT escalate to the URGENT console-recovery path.
+    assert.ok(!sshOkProblems.some(p => /^URGENT/.test(p)), sshOkProblems.join('; '));
+    assert.ok(sshOkProblems.some(p => /reads back as/.test(p)), sshOkProblems.join('; '));
   });
 
   const setFails = mgmtDevice({ fail: cmd => /name="winbox"\] address=/.test(cmd) });


### PR DESCRIPTION
Rebased onto 6.2.4, and **reworked across five rounds of adversarial review**. The first draft could have permanently locked an operator out of a remote router.

## What it does

**Management is unreachable from the WAN under any user config**, not just the default. Previously the only protection was a single firewall rule (`router:input-drop-wan`) — delete it, reorder it, or add a permissive rule above it and the whole admin surface is exposed.

- Every `/ip service` is bound to the LAN network, so RouterOS's own accept path refuses off-LAN connections. The firewall rule stays; the two layers fail independently.
- The **layer-2 surfaces that bypass both** — MAC-telnet, MAC-winbox, neighbour discovery — run over ethernet frames and ignore `/ip service` *and* the IP firewall. They are scoped to the LAN interface list and verified.
- telnet and ftp are disabled: cleartext, and unused by this tool.
- An escape hatch, `lan.management.allow`, can widen access — but its **grammar cannot name a WAN**. Entries must be non-globally-routable, checked on the entry's network address, and re-checked at apply time against addresses actually on the uplinks. Private is not proof: this hardware's own WAN is `192.168.4.0/22`.

**A realistic VAP settle budget.** 6.2.3 allowed ~6 s and produced a false negative in production — it reported an SSID dead and failed the apply, and the interface came up moments later. It now polls against a 60 s shared budget via `pollUntilRunning()`, shared with the deferred-master path.

## Lockout safety

This is the dominant risk: restricting `/ip service` on a remote router can permanently lock the operator out, which is far worse than the exposure being closed.

- The **device** is asked who is connected (`/user active print terse`) — not this process, because a jump host, NAT or VPN rewrites the source address.
- A session that **cannot be parsed blocks the whole restriction**. An IPv6 peer or an address-less record stops it; only `via=local`/`console` is disregarded.
- Prior values are recorded first. **Every write is verified immediately, and any failure rolls the entire run back** to what was actually there.
- **Rollback writes are verified too** — "accepted but did no work" is no less possible on the way out than on the way in.
- SSH is bound last, and if it reads back excluding this session it is cleared and the clear is **confirmed**, with `URGENT` console instructions if it did not land.

## What review caught

Five rounds, ending APPROVED with zero findings. In order:

1. **CRITICAL** — the ssh self-heal relied on `exec()` throwing, which it never did. Root cause fixed separately in #27; the self-heal now also reads back.
2. Unparseable sessions were silently skipped despite the code claiming otherwise.
3. Error text on stdout read as "this is a virtual AP", so a **master radio could be bounced** — cutting every client, possibly the operator's own link.
4. A LAN containing a live uplink address was bound anyway, installing an allow-list that **admits the WAN** while reporting management as LAN-locked.
5. Allow entries were kept when an uplink had no address yet — a DHCP or LTE uplink can take one inside an allowed range moments later.
6. No rollback: a failure partway through left a device half-restricted, and if it landed before ssh, every recovery path was bound while the lifeline was not.
7. A service was added to the rollback set only *after* verification — so the one service whose write landed and whose read-back failed was the one never rolled back.
8. Rollback writes were never verified.
9. Unknown uplink state still bound the LAN range, which is not exempt.
10. The pppoe parent was first *required* to resolve (making the feature permanently inert on pppoe routers, since the parent normally has no address), then *dropped entirely* (making an address it does carry invisible to the overlap check). Resolved by splitting `mustResolve` from `checkAddresses`.

## Known limitation

**Every configured uplink must hold an address during the apply**, or nothing is bound. A disconnected standby link or an LTE backup with no signal defers hardening until it comes up. The apply says so and names the uplink.

There is deliberately **no override**. Ignoring an uplink whose address is unknown is precisely how management ends up reachable from the WAN.

One further finding was accepted rather than fixed: a polling round already in flight runs to completion past its deadline, so a round over many unresponsive radios can overrun by up to 30 s each. Cutting it short would judge the remaining radios on a stale result and report healthy DFS radios as dead. A slow answer beats a wrong one.

## Tests

`npm test`: **205 passed, 0 failed.**

## Not verified

Whether an established SSH session survives an excluding restriction — the self-heal exists because that failure is invisible until the next connect, and I would not prove it on a live gateway. Also the RoMON forbid-on-WAN path (device-mode blocks RoMON, so it is reported rather than changed), and a full `apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1