### PR TITLE
fix: exec() must reject when RouterOS rejects the command (v6.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [6.2.4] - 2026-08-28 - Failed Commands Now Actually Fail
+
+`MikroTikSSH.exec()` resolved whenever stderr was empty. RouterOS prints its
+errors to **stdout** and leaves stderr empty, so a rejected command looked
+exactly like a successful one, and its error message was handed back as if it
+were data.
+
+Every `try { await mt.exec(...) } catch` in this codebase was therefore
+decorative. Read-back verification was the only thing that ever caught a failed
+write, and code that relied on a throw — including safety checks — was relying
+on something that could not happen.
+
+Verified on a live Chateau LTE6 running RouterOS 7.18.2:
+
+```
+/ip service set [find name="ssh"] address=999.999.999.999/99
+  exit 1, stderr "", stdout "invalid value for argument address: ..."
+/bogus/command
+  exit 1, stderr "", stdout "syntax error (line 1 column 7)"
+:put [/interface/wifi/get [find name="nope"] master-interface]
+  exit 1, stderr "", stdout "no such item (...)"
+```
+
+RouterOS does set a non-zero **exit status**, and `exec()` was ignoring it. It
+now rejects on a non-zero exit, on a signal kill, and on stderr as before.
+
+### Why the exit code and not the text
+
+Matching on the output would be worse than useless. `/log print` legitimately
+returns lines containing "failure" and "error"; rejecting those would break
+reads of real data. The exit status is unambiguous. There is a test asserting
+that error-looking text with exit 0 still resolves, so this does not get
+"improved" into a string heuristic later.
+
+### What newly fails
+
+Almost nothing, by design. Checked against real hardware: `remove`, `set` and
+`disable` against an empty `[find ...]`, and `print`/`find` with no matches,
+all exit 0 — so the idempotent patterns this tool is built on are unaffected.
+
+What does now throw is `get` on an item that does not exist, which is a genuine
+error the caller should handle, and any command RouterOS rejects outright.
+Those previously passed silently.
+
+Handled errors are respected. `:do {...} on-error={...}` catching a runtime
+error exits 0, so deliberately-tolerated failures do not start throwing.
+Compound commands separated by `;` propagate a failure in any statement.
+
+One class this does **not** catch: a command that is accepted but answers
+nothing, such as a bare `/interface get ... running` without `:put`. That exits
+0. It is guarded separately by the command-form tests added in 6.2.3.
+
+### Errors never carry secrets
+
+Callers routinely log `e.message`, and WiFi commands carry
+`security.passphrase="..."`. Errors no longer include the command text at all,
+and device output is passed through a redactor before it reaches an exception,
+so a failure cannot be the reason a wireless password lands in a console or a
+CI log.
+
+### A missing exit status is its own case
+
+`ssh2` reports no code when a channel closes without an exit-status request.
+That is not a RouterOS rejection, and reporting it as "exit null" would send
+someone hunting a device error that never happened. It gets a distinct message
+— and still rejects, because an unknown outcome must not be reported as
+success.
+
 ## [6.2.3] - 2026-08-26 - Fix: `get` Needs `:put` (6.2.2 Did Not Work)
 
 **6.2.2 did not work.** The SSID verification it added never functioned on real

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,29 @@ const BAND_TO_INTERFACE = {
 - A comma in `notify.title` would split the RouterOS `http-header-field` into a second header. Validation rejects it.
 - A POST to an unreachable endpoint took ~10s to give up and blocks the tick, so an interval under 10s warns.
 
+**RouterOS Reports Errors On STDOUT With A NON-ZERO EXIT (fixed in 6.2.4)**
+- A rejected command writes its error to **stdout**, leaves **stderr empty**, and exits
+  **non-zero**. Before 6.2.4 `exec()` only rejected on stderr, so it resolved and returned
+  the error text as data. Every `try/catch` around `mt.exec` was decorative.
+- `exec()` now rejects on non-zero exit, on a signal, and on stderr. Verified on hardware.
+- Detect failure by the EXIT CODE, never by matching the output. `/log print` legitimately
+  contains "failure" and "error"; a string heuristic would reject real data. There is a
+  test pinning this - do not replace it with pattern matching.
+- Idempotent patterns are unaffected (verified): `remove`/`set`/`disable` on an empty
+  `[find ...]` and `print`/`find` with no matches all exit 0. `get` on a missing item
+  exits 1 and now throws, which is correct.
+- Exit codes do NOT catch a command that is accepted but answers nothing (a bare
+  `get` without `:put`). That is the separate 6.2.3 trap - see below.
+- Handled errors are respected (verified): `:do {...} on-error={...}` catching a RUNTIME
+  error exits 0. A SYNTAX error inside the block still exits 1, because it fails at parse
+  time and on-error never runs. Compound `a; b` propagates a failure in either statement.
+- Errors must NEVER contain the command text: WiFi commands carry
+  `security.passphrase="..."` and callers log `e.message`. Device output is passed through
+  `redactSecrets()` first. There is a test asserting a passphrase cannot reach an error.
+- A MISSING exit status (ssh2 reports null/undefined when the channel closes without an
+  exit-status request) is distinct from a non-zero one. It still rejects - unknown is not
+  success - but with its own message, not a misleading "exit null".
+
 **RouterOS `get` MUST Be Wrapped In `:put` (learned the hard way in 6.2.2)**
 - `/interface get [find name=X] running` sent over an SSH exec prints NOTHING. RouterOS
   returns the value to an interactive console, not to stdout. Always:

--- a/lib/ssh-client.js
+++ b/lib/ssh-client.js
@@ -5,6 +5,21 @@
 
 const { Client } = require('ssh2');
 
+/**
+ * Strip secrets from anything that might be logged.
+ *
+ * Callers routinely log `e.message`, and WiFi commands carry
+ * `security.passphrase="..."`. An error must never be the reason a wireless
+ * password lands in a console, a CI log, or a bug report.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function redactSecrets(text) {
+  return String(text === undefined || text === null ? '' : text)
+    .replace(/((?:passphrase|password|psk|secret|pre-shared-key)[^\s=]*\s*=\s*)("(?:[^"\\]|\\.)*"|\S+)/gi, '$1<redacted>');
+}
+
 class MikroTikSSH {
   constructor(host, username, password) {
     this.host = host;
@@ -73,11 +88,60 @@ class MikroTikSSH {
 
         stream.on('close', (code, signal) => {
           clearTimeout(timeout);
+
           if (errorOutput) {
             reject(new Error(errorOutput));
-          } else {
-            resolve(output);
+            return;
           }
+
+          if (signal) {
+            // Deliberately WITHOUT the command. WiFi commands contain
+            // security.passphrase="..." and callers log e.message.
+            reject(new Error(`Command killed by signal ${signal}`));
+            return;
+          }
+
+          // RouterOS prints its errors to STDOUT, not stderr, and this method
+          // used to resolve whenever stderr was empty. Every `try { await
+          // mt.exec(...) } catch` in this codebase was therefore decorative: a
+          // rejected command looked exactly like a successful one, and its
+          // error text was returned as if it were data.
+          //
+          // It does, however, set a non-zero exit status. Verified on a live
+          // Chateau LTE6 (RouterOS 7.18.2):
+          //
+          //   /ip service set [find name="ssh"] address=999.999.999.999/99
+          //     exit 1, stderr "", stdout "invalid value for argument address:..."
+          //   /bogus/command
+          //     exit 1, stderr "", stdout "syntax error (line 1 column 7)"
+          //   :put [/interface/wifi/get [find name="nope"] master-interface]
+          //     exit 1, stderr "", stdout "no such item (...)"
+          //
+          // The exit status is the signal to use. Matching on the text would
+          // be worse than useless: `/log print` legitimately returns lines
+          // containing "failure" and "error", and rejecting those would break
+          // reads of real data.
+          const detail = redactSecrets((output || '').trim()) || '(no output)';
+
+          // A missing exit status is NOT the same as a non-zero one. ssh2
+          // reports the code as null/undefined when the channel closes without
+          // an exit-status request, and calling that "exit null" would send
+          // someone hunting a RouterOS rejection that never happened. It still
+          // rejects: an unknown outcome must not be reported as success, which
+          // is the whole point of this change.
+          if (typeof code !== 'number') {
+            reject(new Error(
+              `Connection closed without an exit status, so the command's outcome is unknown. Output: ${detail}`
+            ));
+            return;
+          }
+
+          if (code !== 0) {
+            reject(new Error(`RouterOS rejected the command (exit ${code}): ${detail}`));
+            return;
+          }
+
+          resolve(output);
         }).on('data', (data) => {
           output += data.toString();
         }).stderr.on('data', (data) => {
@@ -97,4 +161,4 @@ class MikroTikSSH {
   }
 }
 
-module.exports = { MikroTikSSH };
+module.exports = { MikroTikSSH, redactSecrets };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-config-as-code",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "YAML-based configuration management for MikroTik network devices",
   "main": "mikrotik-safe-configure.js",
   "scripts": {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -17,6 +17,8 @@ const {
   parseTerseRecord
 } = require('../lib/router');
 const { parseCountry } = require('../lib/backup');
+const { MikroTikSSH, redactSecrets } = require('../lib/ssh-client');
+const { EventEmitter } = require('events');
 const {
   ensureWifiInterfaceUp, recheckPendingMasters, runningQuery
 } = require('../lib/wifi-config');
@@ -1250,6 +1252,116 @@ test('omitting mssClamp is valid and leaves it on', () => {
     const d = recheckDevice([]);
     assert.deepStrictEqual(await recheckPendingMasters(d, [], fastPoll()), []);
     assert.strictEqual(d.sent.length, 0, 'must not talk to the device for an empty list');
+  });
+
+  console.log('\n=== SSH exec must reject RouterOS failures ===');
+
+  // RouterOS prints its errors to STDOUT and leaves stderr empty, so exec()
+  // used to resolve on a rejected command and hand back the error text as if
+  // it were data. Every try/catch around mt.exec in this codebase was therefore
+  // decorative. It DOES set a non-zero exit status, verified on live hardware.
+  const fakeSsh = (opts = {}) => {
+    // NOT destructuring defaults: `code: undefined` must stay undefined, since
+    // a missing exit status is exactly one of the cases under test. A default
+    // would silently turn it into 0 and the test would pass vacuously.
+    const stdout = opts.stdout || '';
+    const stderr = opts.stderr || '';
+    const code = 'code' in opts ? opts.code : 0;
+    const signal = opts.signal;
+    const mt = new MikroTikSSH('192.0.2.1', 'admin', 'admin');
+    mt.connected = true;
+    mt.conn = {
+      exec: (cmd, cb) => {
+        const stream = new EventEmitter();
+        stream.stderr = new EventEmitter();
+        cb(null, stream);
+        setImmediate(() => {
+          if (stdout) stream.emit('data', Buffer.from(stdout));
+          if (stderr) stream.stderr.emit('data', Buffer.from(stderr));
+          stream.emit('close', code, signal);
+        });
+      }
+    };
+    return mt;
+  };
+  const rejects = async mt => {
+    try { await mt.exec('/anything'); return null; } catch (e) { return e.message; }
+  };
+
+  test('a successful command resolves with its output', async () => {
+    const out = await fakeSsh({ stdout: '2d20:57:00\r\n', code: 0 }).exec('/x');
+    assert.strictEqual(out, '2d20:57:00\r\n');
+  });
+
+  test('a non-zero exit REJECTS, even with empty stderr', async () => {
+    // The exact shape observed on a Chateau LTE6 running RouterOS 7.18.2.
+    const msg = await rejects(fakeSsh({
+      stdout: "invalid value for argument address:\r\n    value of address must have ip address before '/'\n",
+      stderr: '', code: 1
+    }));
+    assert.ok(msg, 'must not resolve a rejected command');
+    assert.ok(/exit 1/.test(msg), msg);
+    assert.ok(/invalid value for argument address/.test(msg),
+      `the device's own explanation must survive: ${msg}`);
+  });
+
+  test('stderr still rejects, as it always did', async () => {
+    const msg = await rejects(fakeSsh({ stderr: 'ssh: connection lost', code: 0 }));
+    assert.ok(/connection lost/.test(msg), msg);
+  });
+
+  test('a signal kill rejects', async () => {
+    const msg = await rejects(fakeSsh({ code: null, signal: 'SIGKILL' }));
+    assert.ok(/signal SIGKILL/.test(msg), msg);
+  });
+
+  test('a non-zero exit with no output still rejects, legibly', async () => {
+    const msg = await rejects(fakeSsh({ stdout: '', code: 1 }));
+    assert.ok(/exit 1/.test(msg) && /no output/.test(msg), msg);
+  });
+
+  test('a killed command NEVER leaks the command text', async () => {
+    // WiFi commands carry security.passphrase="..." and callers log e.message.
+    // An error must not be how a wireless password reaches a CI log.
+    const mt = fakeSsh({ code: null, signal: 'SIGKILL' });
+    let msg = '';
+    try {
+      await mt.exec('/interface/wifi set wifi2 security.passphrase="Q#F4Gm8jFM"');
+    } catch (e) { msg = e.message; }
+    assert.ok(/signal SIGKILL/.test(msg), msg);
+    assert.ok(!/Q#F4Gm8jFM/.test(msg), `passphrase leaked into the error: ${msg}`);
+    assert.ok(!/passphrase/i.test(msg), `command text leaked into the error: ${msg}`);
+  });
+
+  test('secrets in device OUTPUT are redacted too', () => {
+    const dirty = '/interface/wifi set x security.passphrase="Q#F4Gm8jFM" ssid="X"';
+    const clean = redactSecrets(dirty);
+    assert.ok(!/Q#F4Gm8jFM/.test(clean), clean);
+    assert.ok(/ssid="X"/.test(clean), 'non-secret arguments must survive for diagnosis');
+    assert.strictEqual(redactSecrets('no such item (/ip/service/get; line 1)'),
+      'no such item (/ip/service/get; line 1)', 'ordinary errors must pass through untouched');
+  });
+
+  test('a MISSING exit status is distinguished from a rejection', async () => {
+    // ssh2 reports no code when the channel closes without an exit-status
+    // request. Calling that "exit null" sends someone hunting a RouterOS
+    // rejection that never happened - but it must still not resolve.
+    for (const code of [null, undefined]) {
+      const msg = await rejects(fakeSsh({ stdout: 'partial', code }));
+      assert.ok(msg, 'an unknown outcome must not resolve');
+      assert.ok(/without an exit status/.test(msg), msg);
+      assert.ok(!/exit null|exit undefined/.test(msg), `misleading message: ${msg}`);
+    }
+  });
+
+  test('legitimate output containing error words is NOT rejected', async () => {
+    // The guard is the EXIT CODE, never the text. `/log print` genuinely
+    // returns lines containing "failure" and "error"; matching on those would
+    // reject real data. Do not "improve" this into a string heuristic.
+    const logLines = '18:25:02 system,error,critical router rebooted without proper shutdown\n'
+      + '18:26:10 script,warning wan-notify: send failed, will retry\n';
+    const out = await fakeSsh({ stdout: logLines, code: 0 }).exec('/log print');
+    assert.strictEqual(out, logLines, 'exit 0 means success no matter what the text says');
   });
 
   console.log('\n=== Host resolution (lockout guard) ===');


### PR DESCRIPTION
## Every try/catch around `mt.exec` in this repo is currently decorative

`MikroTikSSH.exec()` resolves whenever stderr is empty. **RouterOS prints its errors to stdout and leaves stderr empty.** So a rejected command is indistinguishable from a successful one, and its error message is handed back as if it were data.

That means code relying on a throw — including safety checks guarding against operator lockout — relies on something that cannot happen. Read-back verification has been the only thing ever catching a failed write.

Verified on a live Chateau LTE6, RouterOS 7.18.2:

```
/ip service set [find name="ssh"] address=999.999.999.999/99
  exit 1   stderr ""   stdout "invalid value for argument address: ..."
/bogus/command
  exit 1   stderr ""   stdout "syntax error (line 1 column 7)"
:put [/interface/wifi/get [find name="nope"] master-interface]
  exit 1   stderr ""   stdout "no such item (...)"
```

RouterOS **does** set a non-zero exit status. `exec()` was ignoring it — `stream.on('close', (code, signal) => ...)` never looked at `code`.

## The fix

Reject on a non-zero exit, on a signal kill, and on stderr as before.

### Exit code, never the text

Matching output would be worse than useless: `/log print` legitimately returns lines containing "failure" and "error", and rejecting those would break reads of real data. A test asserts that error-looking text with exit 0 still resolves, so this doesn't get "improved" into a string heuristic later.

## Blast radius — measured, not assumed

The worry is that idempotent patterns this tool leans on everywhere would start throwing. Checked against real hardware:

```
remove   [find ...] no match   exit=0     unchanged
set      [find ...] no match   exit=0     unchanged
disable  [find ...] no match   exit=0     unchanged
print / find, no matches       exit=0     unchanged
get on a missing item          exit=1     now throws — genuinely an error
```

So nothing that currently works starts failing. What newly throws is `get` on something that doesn't exist, and any command RouterOS rejects outright — both real errors that previously passed silently.

**One class this does not catch:** a command that is accepted but answers nothing, such as a bare `/interface get ... running` without `:put`. That exits 0. It is guarded separately by the command-form tests from 6.2.3.

## Verified end to end against the live device

Using the real client, not a mock:

```
✓ rejected command THROWS      "RouterOS rejected the command (exit 1): invalid value for argument add..."
✓ bad command THROWS           "...(exit 1): syntax error (line 1 column 7)"
✓ get on missing item THROWS   "...(exit 1): no such item (/interface/wifi/..."
✓ valid read RESOLVES          "2d20:58:51"
✓ idempotent remove RESOLVES   ""
✓ log containing "fail" RESOLVES
6 passed, 0 failed — and nothing on the device changed
```

`npm test`: **137 passed, 0 failed** (6 new).

## Why this is its own PR

This was found while adversarially reviewing #26 (management hardening), whose CRITICAL finding — an SSH self-heal that could permanently lock an operator out of a remote gateway — exists *because* a failed clear looks like a success. Several other findings there share the same root cause.

Landing this separately means #26 can be rebuilt on a client that actually reports failure, and this change gets its own review and release rather than being buried inside a 1700-line security PR. #26 should rebase onto this and become 6.2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnqYCwfdJjsqxNeJmBwE1